### PR TITLE
Reset the `FZF_DEFAULT_OPTS` environment variable

### DIFF
--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -38,6 +38,7 @@ if ! command -v fzf >/dev/null 2>&1; then
 fi
 
 self="${BASH_SOURCE[0]}"
+export FZF_DEFAULT_OPTS=''
 sel=$(emit_rows | fzf --ansi --delimiter='\t' --with-nth=3,4,5 \
   --reverse --cycle --header='Claude sessions · enter: jump · ctrl-x: kill' \
   --preview="tmux capture-pane -ept {2}" --preview-window='right,62%,wrap' \


### PR DESCRIPTION
If we have enabled the `--tmux` flag in the fzf command the picker fails because `tmux` doesn't allow nested sessions.

Example of values that breaks the picker:

```bash
export FZF_DEFAULT_OPTS='--tmux bottom,40% --layout reverse'
```

This PR resets the `FZF_DEFAULT_OPTS` env var to an empty string `''`.