### PR TITLE
Add AI provider menu (Claude/Codex/OpenCode) plus picker & popup polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,40 +152,44 @@ The state machine:
 Set any of these before the plugin loads (defaults shown):
 
 ```tmux
-set -g @claude_launch_key      'y'        # prefix key: launch/open Claude for current dir
-set -g @claude_launch_menu_key 'Y'        # prefix key: open the AI provider menu
-set -g @claude_list_key        'u'        # prefix key: open the picker
-set -g @claude_command         'claude'   # command for the claude provider (override)
-set -g @claude_popup_width      '90%'     # popup width
-set -g @claude_popup_height     '90%'     # popup height
+set -g @ai_launch_key      'y'        # prefix key: launch/open Claude for current dir
+set -g @ai_launch_menu_key 'Y'        # prefix key: open the AI provider menu
+set -g @ai_list_key        'u'        # prefix key: open the picker
+set -g @ai_command         'claude'   # command for the claude provider (override)
+set -g @ai_popup_width      '90%'     # popup width
+set -g @ai_popup_height     '90%'     # popup height
 
 # Providers shown in the `prefix` + `Y` menu and listed by the picker.
 # Space-separated  key:command:Label  entries (command/Label optional).
-set -g @claude_providers 'claude:claude:Claude codex:codex:Codex opencode:opencode:OpenCode'
+set -g @ai_providers 'claude:claude:Claude codex:codex:Codex opencode:opencode:OpenCode'
 ```
+
+> **Back-compat:** every user-facing option also accepts its legacy `@claude_*`
+> spelling (e.g. `@claude_providers`), so existing configs keep working. The
+> `@ai_*` namespace is canonical and takes precedence when both are set.
 
 Each provider gets its own session prefix derived from its key (`claude-`,
 `codex-`, `opencode-`), so the same directory can hold one session per provider
-without collisions. Add or remove providers by overriding `@claude_providers` —
+without collisions. Add or remove providers by overriding `@ai_providers` —
 e.g. drop OpenCode, or add `gemini:gemini:Gemini`.
 
-Because `@claude_providers` is space-delimited, the `command` field there cannot
+Because `@ai_providers` is space-delimited, the `command` field there cannot
 contain arguments. To launch a provider with flags, use the per-provider option
-`@claude_cmd_<key>`, which may contain spaces:
+`@ai_cmd_<key>`, which may contain spaces:
 
 ```tmux
-set -g @claude_cmd_codex 'codex --model o1'
-set -g @claude_cmd_claude 'claude --resume'
+set -g @ai_cmd_codex 'codex --model o1'
+set -g @ai_cmd_claude 'claude --resume'
 ```
 
 ## How it works
 
 - The **launcher** creates a detached `<provider>-<hash-of-dir>` tmux session
   running that provider's command (e.g. `claude-<hash>` running `claude`), records
-  the window it came from in `@claude_origin`, and attaches to it in a popup.
-- The **provider menu** (`prefix` + `Y`) is built from `@claude_providers`; each
+  the window it came from in `@ai_origin`, and attaches to it in a popup.
+- The **provider menu** (`prefix` + `Y`) is built from `@ai_providers`; each
   entry launches via the same launcher with its own command and session prefix.
-- The **hooks** set `@claude_state` / `@claude_state_at` on each session as Claude
+- The **hooks** set `@ai_state` / `@ai_state_at` on each session as Claude
   works.
 - The **picker** lists sessions matching any provider prefix, reads their state and a live
   `capture-pane` preview, and on selection moves your client to the session's

--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ Each provider gets its own session prefix derived from its key (`claude-`,
 without collisions. Add or remove providers by overriding `@claude_providers` —
 e.g. drop OpenCode, or add `gemini:gemini:Gemini`.
 
+Because `@claude_providers` is space-delimited, the `command` field there cannot
+contain arguments. To launch a provider with flags, use the per-provider option
+`@claude_cmd_<key>`, which may contain spaces:
+
+```tmux
+set -g @claude_cmd_codex 'codex --model o1'
+set -g @claude_cmd_claude 'claude --resume'
+```
+
 ## How it works
 
 - The **launcher** creates a detached `<provider>-<hash-of-dir>` tmux session

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ run-shell ~/clone/path/claude_session_manager.tmux
 
 ## Usage
 
-| Key            | Action                                                                          |
-| -------------- | ------------------------------------------------------------------------------- |
-| `prefix` + `y` | Launch (or re-attach to) a Claude session for the current directory, in a popup |
-| `prefix` + `u` | Open the session picker                                                         |
+| Key            | Action                                                                                |
+| -------------- | ------------------------------------------------------------------------------------- |
+| `prefix` + `y` | Launch (or re-attach to) a **Claude** session for the current directory, in a popup   |
+| `prefix` + `Y` | Open the **AI provider menu** (Claude / Codex / OpenCode) and launch the chosen one    |
+| `prefix` + `u` | Open the session picker (lists sessions across all providers)                          |
 
 Inside the picker:
 
@@ -151,22 +152,33 @@ The state machine:
 Set any of these before the plugin loads (defaults shown):
 
 ```tmux
-set -g @claude_launch_key     'y'        # prefix key: launch/open for current dir
-set -g @claude_list_key       'u'        # prefix key: open the picker
-set -g @claude_command        'claude'   # command run in new sessions
-set -g @claude_session_prefix 'claude-'  # tmux session name prefix
-set -g @claude_popup_width     '90%'     # popup width
-set -g @claude_popup_height    '90%'     # popup height
+set -g @claude_launch_key      'y'        # prefix key: launch/open Claude for current dir
+set -g @claude_launch_menu_key 'Y'        # prefix key: open the AI provider menu
+set -g @claude_list_key        'u'        # prefix key: open the picker
+set -g @claude_command         'claude'   # command for the claude provider (override)
+set -g @claude_popup_width      '90%'     # popup width
+set -g @claude_popup_height     '90%'     # popup height
+
+# Providers shown in the `prefix` + `Y` menu and listed by the picker.
+# Space-separated  key:command:Label  entries (command/Label optional).
+set -g @claude_providers 'claude:claude:Claude codex:codex:Codex opencode:opencode:OpenCode'
 ```
+
+Each provider gets its own session prefix derived from its key (`claude-`,
+`codex-`, `opencode-`), so the same directory can hold one session per provider
+without collisions. Add or remove providers by overriding `@claude_providers` —
+e.g. drop OpenCode, or add `gemini:gemini:Gemini`.
 
 ## How it works
 
-- The **launcher** creates a detached `claude-<hash-of-dir>` tmux session running
-  `claude`, records the window it came from in `@claude_origin`, and attaches to
-  it in a popup.
+- The **launcher** creates a detached `<provider>-<hash-of-dir>` tmux session
+  running that provider's command (e.g. `claude-<hash>` running `claude`), records
+  the window it came from in `@claude_origin`, and attaches to it in a popup.
+- The **provider menu** (`prefix` + `Y`) is built from `@claude_providers`; each
+  entry launches via the same launcher with its own command and session prefix.
 - The **hooks** set `@claude_state` / `@claude_state_at` on each session as Claude
   works.
-- The **picker** lists sessions matching the prefix, reads their state and a live
+- The **picker** lists sessions matching any provider prefix, reads their state and a live
   `capture-pane` preview, and on selection moves your client to the session's
   origin window before resuming it in the popup.
 - Pressing `prefix` + `u` **from inside a session popup** detaches that popup

--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ set -g @claude_cmd_claude 'claude --resume'
   first (closing it), then reopens the picker full-size on the outer host client —
   so you never end up with a cramped popup-in-popup.
 
+## Development
+
+Unit tests for the pure helpers (no tmux required — it is stubbed):
+
+```bash
+./tests/run.sh
+```
+
 ## License
 
 [MIT](LICENSE) © Takuya Matsuyama

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ set -g @ai_list_key        'u'        # prefix key: open the picker
 set -g @ai_command         'claude'   # command for the claude provider (override)
 set -g @ai_popup_width      '90%'     # popup width
 set -g @ai_popup_height     '90%'     # popup height
+set -g @ai_picker_opts      ''        # extra fzf flags for the picker (see below)
 
 # Providers shown in the `prefix` + `Y` menu and listed by the picker.
 # Space-separated  key:command:Label  entries (command/Label optional).
@@ -181,6 +182,21 @@ contain arguments. To launch a provider with flags, use the per-provider option
 set -g @ai_cmd_codex 'codex --model o1'
 set -g @ai_cmd_claude 'claude --resume'
 ```
+
+### Customizing the picker
+
+The picker inherits your global `FZF_DEFAULT_OPTS` (theme, keybindings) and pins
+only the flags it needs for its layout — a 3/7 list/preview split and full popup
+height (`--height=100%`, which overrides a `--height` you may have set in
+`FZF_DEFAULT_OPTS`). To tweak the picker without editing the script, append flags
+via `@ai_picker_opts`; they are applied last and win over everything else:
+
+```tmux
+set -g @ai_picker_opts '--color=preview-border:6,list-border:8 --preview-window=right,60%'
+```
+
+Tokens are space-split, so use it for a list of simple flags; flag values that
+contain spaces are not supported through this option.
 
 ## How it works
 

--- a/claude_session_manager.tmux
+++ b/claude_session_manager.tmux
@@ -10,13 +10,28 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$CURRENT_DIR/scripts/helpers.sh"
 
 launch_key="$(get_tmux_option @claude_launch_key 'y')"
+launch_menu_key="$(get_tmux_option @claude_launch_menu_key 'Y')"
 list_key="$(get_tmux_option @claude_list_key 'u')"
 
 # Launch (or re-attach to) a Claude session for the current pane's directory.
 # #{pane_current_path} / #{window_id} are expanded by run-shell before the args
 # reach the script.
 tmux bind-key "$launch_key" \
-  run-shell "$CURRENT_DIR/scripts/launch.sh '#{pane_current_path}' '#{window_id}'"
+  run-shell "$CURRENT_DIR/scripts/launch.sh '#{pane_current_path}' '#{window_id}' claude"
+
+# Provider menu: pick which AI CLI to launch for the current pane's directory.
+# Built from @claude_providers; each entry gets a numeric shortcut (1, 2, 3, …).
+menu_args=()
+i=0
+for entry in $(get_providers); do
+  i=$((i + 1))
+  IFS=: read -r key _ label <<<"$entry"
+  [ -z "$label" ] && label="$key"
+  menu_args+=("$label" "$i" \
+    "run-shell \"$CURRENT_DIR/scripts/launch.sh '#{pane_current_path}' '#{window_id}' $key\"")
+done
+tmux bind-key "$launch_menu_key" \
+  display-menu -T ' AI Provider ' -x C -y C "${menu_args[@]}"
 
 # Open the session picker. When pressed from inside a session popup, list.sh
 # closes that popup first so the picker opens full-size on the outer client.

--- a/claude_session_manager.tmux
+++ b/claude_session_manager.tmux
@@ -9,9 +9,9 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/helpers.sh
 . "$CURRENT_DIR/scripts/helpers.sh"
 
-launch_key="$(get_tmux_option @claude_launch_key 'y')"
-launch_menu_key="$(get_tmux_option @claude_launch_menu_key 'Y')"
-list_key="$(get_tmux_option @claude_list_key 'u')"
+launch_key="$(get_opt launch_key 'y')"
+launch_menu_key="$(get_opt launch_menu_key 'Y')"
+list_key="$(get_opt list_key 'u')"
 
 # Launch (or re-attach to) a Claude session for the current pane's directory.
 # #{pane_current_path} / #{window_id} are expanded by run-shell before the args
@@ -20,7 +20,7 @@ tmux bind-key "$launch_key" \
   run-shell "$CURRENT_DIR/scripts/launch.sh '#{pane_current_path}' '#{window_id}' claude"
 
 # Provider menu: pick which AI CLI to launch for the current pane's directory.
-# Built from @claude_providers; each entry gets a numeric shortcut (1, 2, 3, …).
+# Built from @ai_providers; each entry gets a numeric shortcut (1, 2, 3, …).
 menu_args=()
 i=0
 for entry in $(get_providers); do

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -13,6 +13,14 @@ get_tmux_option() {
   fi
 }
 
+# popup_dims -> "<width> <height>" for display-popup, from @claude_popup_width /
+# @claude_popup_height (defaults 90%/90%). Read with: read -r w h < <(popup_dims)
+popup_dims() {
+  printf '%s %s' \
+    "$(get_tmux_option @claude_popup_width '90%')" \
+    "$(get_tmux_option @claude_popup_height '90%')"
+}
+
 # ---------------------------------------------------------------------------
 # AI providers
 #

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -13,22 +13,36 @@ get_tmux_option() {
   fi
 }
 
-# popup_dims -> "<width> <height>" for display-popup, from @claude_popup_width /
-# @claude_popup_height (defaults 90%/90%). Read with: read -r w h < <(popup_dims)
+# get_opt <suffix> <default>
+# Reads the user-facing option @ai_<suffix>, falling back to the deprecated
+# @claude_<suffix> alias, then <default>. All user-facing options go through this
+# so the plugin's @ai_* namespace is canonical while existing @claude_* configs
+# keep working unchanged.
+get_opt() {
+  local value
+  value="$(tmux show-option -gqv "@ai_$1" 2>/dev/null)"
+  [ -n "$value" ] && { printf '%s' "$value"; return; }
+  value="$(tmux show-option -gqv "@claude_$1" 2>/dev/null)"
+  [ -n "$value" ] && { printf '%s' "$value"; return; }
+  printf '%s' "$2"
+}
+
+# popup_dims -> "<width> <height>" for display-popup, from @ai_popup_width /
+# @ai_popup_height (defaults 90%/90%). Read with: read -r w h < <(popup_dims)
 popup_dims() {
   printf '%s %s' \
-    "$(get_tmux_option @claude_popup_width '90%')" \
-    "$(get_tmux_option @claude_popup_height '90%')"
+    "$(get_opt popup_width '90%')" \
+    "$(get_opt popup_height '90%')"
 }
 
 # ---------------------------------------------------------------------------
 # AI providers
 #
 # A provider is one launchable AI CLI (Claude, Codex, OpenCode, ...). The set is
-# configurable via the @claude_providers tmux option as a space-separated list
+# configurable via the @ai_providers tmux option as a space-separated list
 # of  key:command:Label  entries:
 #
-#   set -g @claude_providers 'claude:claude:Claude codex:codex:Codex'
+#   set -g @ai_providers 'claude:claude:Claude codex:codex:Codex'
 #
 # - key     identifies the provider and forms its session prefix ("claude-").
 # - command is what runs inside the session (defaults to key when omitted).
@@ -37,7 +51,7 @@ popup_dims() {
 default_providers='claude:claude:Claude codex:codex:Codex opencode:opencode:OpenCode'
 
 get_providers() {
-  get_tmux_option @claude_providers "$default_providers"
+  get_opt providers "$default_providers"
 }
 
 # provider_prefix <key> -> session-name prefix, e.g. "claude-"
@@ -45,19 +59,20 @@ provider_prefix() { printf '%s-' "$1"; }
 
 # provider_command <key> -> command to run for that provider.
 # Resolution order (first non-empty wins):
-#   1. @claude_cmd_<key>  per-provider option — may contain spaces/flags, e.g.
-#                         set -g @claude_cmd_codex 'codex --model o1'
-#   2. @claude_command    legacy override, claude provider only (back-compat)
-#   3. the command field of the @claude_providers entry (no spaces — see header)
+#   1. @ai_cmd_<key>  per-provider option — may contain spaces/flags, e.g.
+#                     set -g @ai_cmd_codex 'codex --model o1'
+#   2. @ai_command    override, claude provider only (legacy @claude_command alias)
+#   3. the command field of the @ai_providers entry (no spaces — see header)
 #   4. the key itself
-# The per-provider option exists because @claude_providers is space-delimited and
+# (1) and (2) also accept the deprecated @claude_* spelling via get_opt. The
+# per-provider option exists because @ai_providers is space-delimited and
 # therefore cannot carry a command with arguments; this option can.
 provider_command() {
   local want="$1" entry key command override
-  override="$(tmux show-option -gqv "@claude_cmd_${want}" 2>/dev/null)"
+  override="$(get_opt "cmd_${want}" '')"
   [ -n "$override" ] && { printf '%s' "$override"; return; }
   if [ "$want" = claude ]; then
-    override="$(tmux show-option -gqv @claude_command 2>/dev/null)"
+    override="$(get_opt command '')"
     [ -n "$override" ] && { printf '%s' "$override"; return; }
   fi
   for entry in $(get_providers); do

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 # Shared helpers for tmux-claude-session-manager.
 
-# get_tmux_option <option-name> <default>
-# Echoes the global tmux option value, or the default when unset/empty.
-get_tmux_option() {
-  local value
-  value="$(tmux show-option -gqv "$1" 2>/dev/null)"
-  if [ -n "$value" ]; then
-    printf '%s' "$value"
-  else
-    printf '%s' "$2"
-  fi
-}
-
 # get_opt <suffix> <default>
 # Reads the user-facing option @ai_<suffix>, falling back to the deprecated
 # @claude_<suffix> alias, then <default>. All user-facing options go through this

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -13,6 +13,69 @@ get_tmux_option() {
   fi
 }
 
+# ---------------------------------------------------------------------------
+# AI providers
+#
+# A provider is one launchable AI CLI (Claude, Codex, OpenCode, ...). The set is
+# configurable via the @claude_providers tmux option as a space-separated list
+# of  key:command:Label  entries:
+#
+#   set -g @claude_providers 'claude:claude:Claude codex:codex:Codex'
+#
+# - key     identifies the provider and forms its session prefix ("claude-").
+# - command is what runs inside the session (defaults to key when omitted).
+# - Label   is shown in the launch menu and picker (defaults to key).
+# ---------------------------------------------------------------------------
+default_providers='claude:claude:Claude codex:codex:Codex opencode:opencode:OpenCode'
+
+get_providers() {
+  get_tmux_option @claude_providers "$default_providers"
+}
+
+# provider_prefix <key> -> session-name prefix, e.g. "claude-"
+provider_prefix() { printf '%s-' "$1"; }
+
+# provider_command <key> -> command to run for that provider.
+# Honors @claude_command as an override for the claude provider (back-compat).
+provider_command() {
+  local want="$1" entry key command
+  if [ "$want" = claude ]; then
+    local override
+    override="$(tmux show-option -gqv @claude_command 2>/dev/null)"
+    [ -n "$override" ] && { printf '%s' "$override"; return; }
+  fi
+  for entry in $(get_providers); do
+    IFS=: read -r key command _ <<<"$entry"
+    [ "$key" = "$want" ] && { printf '%s' "${command:-$key}"; return; }
+  done
+  printf '%s' "$want"
+}
+
+# provider_of_session <session-name> -> provider key (text before the hash).
+# Session names are "<key>-<8charhash>" and keys contain no dash.
+provider_of_session() { printf '%s' "${1%-*}"; }
+
+# provider_label <key> -> human label from the providers list (defaults to key).
+provider_label() {
+  local want="$1" entry key label
+  for entry in $(get_providers); do
+    IFS=: read -r key _ label <<<"$entry"
+    [ "$key" = "$want" ] && { printf '%s' "${label:-$key}"; return; }
+  done
+  printf '%s' "$want"
+}
+
+# provider_prefixes_regex -> alternation of every provider prefix, e.g.
+# "claude-|codex-|opencode-" for anchoring grep/awk matches.
+provider_prefixes_regex() {
+  local entry key out=''
+  for entry in $(get_providers); do
+    IFS=: read -r key _ _ <<<"$entry"
+    out="${out}${out:+|}$(provider_prefix "$key")"
+  done
+  printf '%s' "$out"
+}
+
 # session_hash <string>
 # Short, stable, portable 8-char hash for deriving a session name from a path.
 # Prefers md5sum (Linux), falls back to md5 (macOS) then shasum. The trailing

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -36,11 +36,19 @@ get_providers() {
 provider_prefix() { printf '%s-' "$1"; }
 
 # provider_command <key> -> command to run for that provider.
-# Honors @claude_command as an override for the claude provider (back-compat).
+# Resolution order (first non-empty wins):
+#   1. @claude_cmd_<key>  per-provider option — may contain spaces/flags, e.g.
+#                         set -g @claude_cmd_codex 'codex --model o1'
+#   2. @claude_command    legacy override, claude provider only (back-compat)
+#   3. the command field of the @claude_providers entry (no spaces — see header)
+#   4. the key itself
+# The per-provider option exists because @claude_providers is space-delimited and
+# therefore cannot carry a command with arguments; this option can.
 provider_command() {
-  local want="$1" entry key command
+  local want="$1" entry key command override
+  override="$(tmux show-option -gqv "@claude_cmd_${want}" 2>/dev/null)"
+  [ -n "$override" ] && { printf '%s' "$override"; return; }
   if [ "$want" = claude ]; then
-    local override
     override="$(tmux show-option -gqv @claude_command 2>/dev/null)"
     [ -n "$override" ] && { printf '%s' "$override"; return; }
   fi

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -19,8 +19,16 @@ h="$(get_tmux_option @claude_popup_height '90%')"
 
 session="${prefix}$(session_hash "$path")"
 
-tmux has-session -t "$session" 2>/dev/null \
-  || tmux new-session -d -s "$session" -c "$path" "$cmd"
+if ! tmux has-session -t "$session" 2>/dev/null; then
+  # Fail loudly instead of spawning a session that dies instantly when the
+  # provider CLI is missing. ${cmd%% *} strips any arguments so we test the
+  # binary, not the whole command line.
+  if ! command -v "${cmd%% *}" >/dev/null 2>&1; then
+    tmux display-message "claude-session-manager: '${cmd%% *}' not found in PATH"
+    exit 0
+  fi
+  tmux new-session -d -s "$session" -c "$path" "$cmd"
+fi
 
 # Record which window launched it, so the picker can jump back here later.
 [ -n "$window" ] && tmux set-option -t "$session" @claude_origin "$window"

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -30,6 +30,6 @@ if ! tmux has-session -t "$session" 2>/dev/null; then
 fi
 
 # Record which window launched it, so the picker can jump back here later.
-[ -n "$window" ] && tmux set-option -t "$session" @claude_origin "$window"
+[ -n "$window" ] && tmux set-option -t "$session" @ai_origin "$window"
 
 tmux display-popup -w "$w" -h "$h" -E "tmux attach-session -t $session"

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Launch (or re-attach to) a Claude session for a directory, shown in a popup.
-# Args: <dir> [origin-window-id]   (both expanded by run-shell in the binding)
+# Launch (or re-attach to) an AI session for a directory, shown in a popup.
+# Args: <dir> [origin-window-id] [provider]
+#   dir/window are expanded by run-shell in the binding; provider defaults to
+#   'claude' so the legacy prefix+y binding keeps working unchanged.
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
@@ -8,9 +10,10 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 path="${1:-$PWD}"
 window="${2:-}"
+provider="${3:-claude}"
 
-prefix="$(get_tmux_option @claude_session_prefix 'claude-')"
-cmd="$(get_tmux_option @claude_command 'claude')"
+prefix="$(provider_prefix "$provider")"
+cmd="$(provider_command "$provider")"
 w="$(get_tmux_option @claude_popup_width '90%')"
 h="$(get_tmux_option @claude_popup_height '90%')"
 

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -14,8 +14,7 @@ provider="${3:-claude}"
 
 prefix="$(provider_prefix "$provider")"
 cmd="$(provider_command "$provider")"
-w="$(get_tmux_option @claude_popup_width '90%')"
-h="$(get_tmux_option @claude_popup_height '90%')"
+read -r w h < <(popup_dims)
 
 session="${prefix}$(session_hash "$path")"
 

--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -5,22 +5,22 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
 . "$DIR/helpers.sh"
 
-prefix="$(get_tmux_option @claude_session_prefix 'claude-')"
+prefixes_re="^($(provider_prefixes_regex))"
 w="$(get_tmux_option @claude_popup_width '90%')"
 h="$(get_tmux_option @claude_popup_height '90%')"
 
-# The session of a client attached to a prefixed session — i.e. the popup we are
-# inside, if any. Empty when invoked from a normal (non-popup) pane.
+# The session of a client attached to a managed (provider-prefixed) session —
+# i.e. the popup we are inside, if any. Empty when invoked from a normal pane.
 nested_session() {
   tmux list-clients -F '#{client_name} #{session_name}' 2>/dev/null |
-    awk -v p="$prefix" 'index($2, p) == 1 { print $2; exit }'
+    awk -v re="$prefixes_re" '$2 ~ re { print $2; exit }'
 }
 
-# A client NOT attached to a prefixed session — the outer client that should host
+# A client NOT attached to a managed session — the outer client that should host
 # the picker popup.
 host_client() {
   tmux list-clients -F '#{client_name} #{session_name}' 2>/dev/null |
-    awk -v p="$prefix" 'index($2, p) != 1 { print $1; exit }'
+    awk -v re="$prefixes_re" '$2 !~ re { print $1; exit }'
 }
 
 # If we are inside a session popup, close it (detach its client)

--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -34,7 +34,7 @@ if [ -n "$sess" ]; then
 fi
 
 host="$(host_client)"
-tmux set-option -g @claude_parent "$host"
+tmux set-option -g @ai_parent "$host"
 
 # Host the picker on the outer client. -c is honored because that client has no
 # popup open now; fall back to the default client if none was found.

--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -25,7 +25,8 @@ host_client() {
     awk -v re="$prefixes_re" '$2 !~ re { print $1; exit }'
 }
 
-tmux set-option -g @ai_parent "$(host_client)"
+host="$(host_client)"
+tmux set-option -g @ai_parent "$host"
 
 caller_session=""
 [ -n "$caller" ] &&
@@ -38,7 +39,6 @@ if [ -n "$caller_session" ] && printf '%s' "$caller_session" | grep -qE "$prefix
 else
   # Normal pane: clear any stale caller so picker.sh uses the morph path.
   tmux set-option -gu @ai_caller 2>/dev/null || true
-  host="$(host_client)"
   if [ -n "$host" ]; then
     tmux display-popup -c "$host" -w "$w" -h "$h" -E "$DIR/picker.sh"
   else

--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # Open the session picker in a popup.
 #
-# When invoked from inside a session popup, the picker must reopen full-size on
-# the outer (host) client — a popup-in-popup would be cramped. We do the swap in
-# a single tmux command: `display-popup -C` closes any popup already on the host,
-# and the chained `display-popup` opens the picker. Running both in one command
-# queue makes tmux repaint once, so there is no flash of the underlying session
-# between closing the old popup and showing the picker. (The previous approach
-# detached the popup client and polled with sleeps, which left a visible gap.)
+# Two cases:
+#   * Pressed from inside a session popup (the caller client is attached to a
+#     managed session): open the picker *nested* on that same client, on top of
+#     the current session. Nothing is closed, so the outer session is never
+#     revealed — no flash. picker.sh then switches this client to the chosen
+#     session in place; the nested popup closes, revealing the target.
+#   * Pressed from a normal pane: open the picker on the host client and let
+#     picker.sh morph it into the chosen session (the original behavior).
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
@@ -15,23 +16,32 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 prefixes_re="^($(provider_prefixes_regex))"
 read -r w h < <(popup_dims)
+caller="${1:-}"  # #{client_name} of the client that pressed the key
 
-# A client NOT attached to a managed (provider-prefixed) session — the outer
-# client that should host the picker popup.
+# A client NOT attached to a managed session — the outer client that hosts the
+# picker in the non-nested case (and the morph fallback in picker.sh).
 host_client() {
   tmux list-clients -F '#{client_name} #{session_name}' 2>/dev/null |
     awk -v re="$prefixes_re" '$2 !~ re { print $1; exit }'
 }
 
-host="$(host_client)"
-tmux set-option -g @ai_parent "$host"
+tmux set-option -g @ai_parent "$(host_client)"
 
-# Close any popup already open on the host, then open the picker — one command
-# queue, one repaint. When invoked from a normal pane the -C is a harmless no-op.
-if [ -n "$host" ]; then
-  tmux display-popup -C -c "$host" \
-    \; display-popup -c "$host" -w "$w" -h "$h" -E "$DIR/picker.sh"
+caller_session=""
+[ -n "$caller" ] &&
+  caller_session=$(tmux display-message -p -t "$caller" '#{session_name}' 2>/dev/null)
+
+if [ -n "$caller_session" ] && printf '%s' "$caller_session" | grep -qE "$prefixes_re"; then
+  # Nested: draw the picker over the caller's session popup, no close/reopen.
+  tmux set-option -g @ai_caller "$caller"
+  tmux display-popup -c "$caller" -w "$w" -h "$h" -E "$DIR/picker.sh"
 else
-  tmux display-popup -C \
-    \; display-popup -w "$w" -h "$h" -E "$DIR/picker.sh"
+  # Normal pane: clear any stale caller so picker.sh uses the morph path.
+  tmux set-option -gu @ai_caller 2>/dev/null || true
+  host="$(host_client)"
+  if [ -n "$host" ]; then
+    tmux display-popup -c "$host" -w "$w" -h "$h" -E "$DIR/picker.sh"
+  else
+    tmux display-popup -w "$w" -h "$h" -E "$DIR/picker.sh"
+  fi
 fi

--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -6,8 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$DIR/helpers.sh"
 
 prefixes_re="^($(provider_prefixes_regex))"
-w="$(get_tmux_option @claude_popup_width '90%')"
-h="$(get_tmux_option @claude_popup_height '90%')"
+read -r w h < <(popup_dims)
 
 # The session of a client attached to a managed (provider-prefixed) session —
 # i.e. the popup we are inside, if any. Empty when invoked from a normal pane.

--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 # Open the session picker in a popup.
+#
+# When invoked from inside a session popup, the picker must reopen full-size on
+# the outer (host) client — a popup-in-popup would be cramped. We do the swap in
+# a single tmux command: `display-popup -C` closes any popup already on the host,
+# and the chained `display-popup` opens the picker. Running both in one command
+# queue makes tmux repaint once, so there is no flash of the underlying session
+# between closing the old popup and showing the picker. (The previous approach
+# detached the popup client and polled with sleeps, which left a visible gap.)
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
@@ -8,38 +16,22 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 prefixes_re="^($(provider_prefixes_regex))"
 read -r w h < <(popup_dims)
 
-# The session of a client attached to a managed (provider-prefixed) session —
-# i.e. the popup we are inside, if any. Empty when invoked from a normal pane.
-nested_session() {
-  tmux list-clients -F '#{client_name} #{session_name}' 2>/dev/null |
-    awk -v re="$prefixes_re" '$2 ~ re { print $2; exit }'
-}
-
-# A client NOT attached to a managed session — the outer client that should host
-# the picker popup.
+# A client NOT attached to a managed (provider-prefixed) session — the outer
+# client that should host the picker popup.
 host_client() {
   tmux list-clients -F '#{client_name} #{session_name}' 2>/dev/null |
     awk -v re="$prefixes_re" '$2 !~ re { print $1; exit }'
 }
 
-# If we are inside a session popup, close it (detach its client)
-sess="$(nested_session)"
-if [ -n "$sess" ]; then
-  tmux detach-client -s "$sess"
-  # Wait until the session is gone
-  for _ in $(seq 1 100); do
-    [ -z "$(nested_session)" ] && break
-    sleep 0.05
-  done
-fi
-
 host="$(host_client)"
 tmux set-option -g @ai_parent "$host"
 
-# Host the picker on the outer client. -c is honored because that client has no
-# popup open now; fall back to the default client if none was found.
+# Close any popup already open on the host, then open the picker — one command
+# queue, one repaint. When invoked from a normal pane the -C is a harmless no-op.
 if [ -n "$host" ]; then
-  tmux display-popup -c "$host" -w "$w" -h "$h" -E "$DIR/picker.sh"
+  tmux display-popup -C -c "$host" \
+    \; display-popup -c "$host" -w "$w" -h "$h" -E "$DIR/picker.sh"
 else
-  tmux display-popup -w "$w" -h "$h" -E "$DIR/picker.sh"
+  tmux display-popup -C \
+    \; display-popup -w "$w" -h "$h" -E "$DIR/picker.sh"
 fi

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -15,7 +15,7 @@ emit_rows() {
   local now s state at path icon rank ago provider
   now=$(date +%s)
   # One tmux call pulls every session's name, state, timestamp and path at once.
-  # Session-scoped user options are read inline via #{@claude_state} etc., so we
+  # Session-scoped user options are read inline via #{@ai_state} etc., so we
   # avoid the previous per-session show-options/display-message subprocess fan-out.
   while IFS=$'\t' read -r s state at path; do
     provider=$(provider_label "$(provider_of_session "$s")")
@@ -29,7 +29,7 @@ emit_rows() {
     # rank \t session \t provider \t icon \t path \t age  (rank/session hidden via --with-nth)
     printf '%s\t%s\t%-9s\t%s\t%s\t%s\n' "$rank" "$s" "$provider" "$icon" "${path/#$HOME/~}" "$ago"
   done < <(tmux list-sessions \
-             -F "#{session_name}	#{@claude_state}	#{@claude_state_at}	#{pane_current_path}" \
+             -F "#{session_name}	#{@ai_state}	#{@ai_state_at}	#{pane_current_path}" \
              2>/dev/null | grep -E "^(${prefixes_re})") |
     sort -n # attention-needed (waiting, idle) float to the top
 }
@@ -53,8 +53,8 @@ target=$(printf '%s' "$sel" | cut -f2)
 # Move the underlying parent client to the session's origin window (best-effort),
 # then resume the session in THIS popup over it. Falls back to resuming over the
 # current window when origin/parent are unknown.
-origin=$(tmux show-options -qv -t "$target" @claude_origin 2>/dev/null)
-parent=$(tmux show-options -gqv @claude_parent 2>/dev/null)
+origin=$(tmux show-options -qv -t "$target" @ai_origin 2>/dev/null)
+parent=$(tmux show-options -gqv @ai_parent 2>/dev/null)
 [ -n "$origin" ] && [ -n "$parent" ] && \
   tmux switch-client -c "$parent" -t "$origin" 2>/dev/null
 

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -90,9 +90,17 @@ sel=$(emit_rows | fzf "${fzf_opts[@]}")
 [ -z "$sel" ] && exit 0
 target=$(printf '%s' "$sel" | cut -f2)
 
-# Move the underlying parent client to the session's origin window (best-effort),
-# then resume the session in THIS popup over it. Falls back to resuming over the
-# current window when origin/parent are unknown.
+# Nested case: list.sh recorded the popup client that opened us. Switch that
+# client to the chosen session in place — the nested popup then closes, revealing
+# the target with no popup close/reopen (hence no flash).
+caller=$(tmux show-options -gqv @ai_caller 2>/dev/null)
+if [ -n "$caller" ]; then
+  tmux switch-client -c "$caller" -t "$target" 2>/dev/null
+  exit 0
+fi
+
+# Non-nested fallback: move the host client to the session's origin window, then
+# resume the session in THIS popup over it.
 origin=$(tmux show-options -qv -t "$target" @ai_origin 2>/dev/null)
 parent=$(tmux show-options -gqv @ai_parent 2>/dev/null)
 [ -n "$origin" ] && [ -n "$parent" ] && \

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -44,9 +44,12 @@ fi
 self="${BASH_SOURCE[0]}"
 
 # Base options shared by every fzf version.
+# --height=100% fills the whole popup; it overrides any --height (e.g. 40%) the
+# user set in FZF_DEFAULT_OPTS, which would otherwise leave the lower part of the
+# popup blank. Command-line opts win over FZF_DEFAULT_OPTS.
 fzf_opts=(
   --ansi --delimiter='\t' --with-nth=3,4,5,6
-  --reverse --cycle
+  --reverse --cycle --height=100%
   --preview="tmux capture-pane -ept {2}"
   --preview-window='right,70%,wrap'  # 3/7 split: list 30% · preview 70%
   --bind="ctrl-x:execute-silent(tmux kill-session -t {2})+reload($self --list)"

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -94,13 +94,12 @@ target=$(printf '%s' "$sel" | cut -f2)
 # client to the chosen session in place — the nested popup then closes, revealing
 # the target with no popup close/reopen (hence no flash).
 caller=$(tmux show-options -gqv @ai_caller 2>/dev/null)
-if [ -n "$caller" ]; then
-  tmux switch-client -c "$caller" -t "$target" 2>/dev/null
+if [ -n "$caller" ] && tmux switch-client -c "$caller" -t "$target" 2>/dev/null; then
   exit 0
 fi
 
-# Non-nested fallback: move the host client to the session's origin window, then
-# resume the session in THIS popup over it.
+# Fallback (normal pane, or the in-place switch failed): move the host client to
+# the session's origin window, then resume the session in THIS popup over it.
 origin=$(tmux show-options -qv -t "$target" @ai_origin 2>/dev/null)
 parent=$(tmux show-options -gqv @ai_parent 2>/dev/null)
 [ -n "$origin" ] && [ -n "$parent" ] && \

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -73,6 +73,18 @@ else
   fzf_opts+=(--header='AI sessions · enter: jump · ctrl-x: kill')
 fi
 
+# User escape hatch. @ai_picker_opts is appended last, so it overrides anything
+# above (theme, --info, extra binds — even layout flags if the user insists)
+# without editing this script. Tokens are space-split, so it suits a list of
+# simple flags; values containing spaces are not supported here. The guard keeps
+# bash 3.2 (stock macOS) happy, where expanding an empty array under `set -u`
+# raises "unbound variable".
+extra_opts="$(get_opt picker_opts '')"
+if [ -n "$extra_opts" ]; then
+  read -ra extra_arr <<<"$extra_opts"
+  fzf_opts+=("${extra_arr[@]}")
+fi
+
 sel=$(emit_rows | fzf "${fzf_opts[@]}")
 
 [ -z "$sel" ] && exit 0

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -9,15 +9,16 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
 . "$DIR/helpers.sh"
 
-prefix="$(get_tmux_option @claude_session_prefix 'claude-')"
+prefixes_re="$(provider_prefixes_regex)"
 
 emit_rows() {
-  local now s state at path icon rank ago
+  local now s state at path icon rank ago provider
   now=$(date +%s)
-  tmux list-sessions -F '#{session_name}' 2>/dev/null | grep "^${prefix}" | while IFS= read -r s; do
+  tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E "^(${prefixes_re})" | while IFS= read -r s; do
     state=$(tmux show-options -qv -t "$s" @claude_state 2>/dev/null)
     at=$(tmux show-options -qv -t "$s" @claude_state_at 2>/dev/null)
     path=$(tmux display-message -p -t "$s" '#{pane_current_path}' 2>/dev/null)
+    provider=$(provider_label "$(provider_of_session "$s")")
     case "$state" in
       waiting) icon=$'\033[33m●\033[0m waiting' rank=0 ;; # yellow - needs input
       idle)    icon=$'\033[32m●\033[0m idle   ' rank=1 ;; # green  - done, your turn
@@ -25,8 +26,8 @@ emit_rows() {
       *)       icon=$'\033[90m●\033[0m   ?    ' rank=2 ;; # grey   - unknown (no hook yet)
     esac
     if [ -n "$at" ]; then ago="$(( (now - at) / 60 ))m"; else ago='-'; fi
-    # rank \t session \t icon \t path \t age   (rank/session hidden via --with-nth)
-    printf '%s\t%s\t%s\t%s\t%s\n' "$rank" "$s" "$icon" "${path/#$HOME/~}" "$ago"
+    # rank \t session \t provider \t icon \t path \t age  (rank/session hidden via --with-nth)
+    printf '%s\t%s\t%-9s\t%s\t%s\t%s\n' "$rank" "$s" "$provider" "$icon" "${path/#$HOME/~}" "$ago"
   done | sort -n # attention-needed (waiting, idle) float to the top
 }
 
@@ -38,8 +39,8 @@ if ! command -v fzf >/dev/null 2>&1; then
 fi
 
 self="${BASH_SOURCE[0]}"
-sel=$(emit_rows | fzf --ansi --delimiter='\t' --with-nth=3,4,5 \
-  --reverse --cycle --header='Claude sessions · enter: jump · ctrl-x: kill' \
+sel=$(emit_rows | fzf --ansi --delimiter='\t' --with-nth=3,4,5,6 \
+  --reverse --cycle --header='AI sessions · enter: jump · ctrl-x: kill' \
   --preview="tmux capture-pane -ept {2}" --preview-window='right,62%,wrap' \
   --bind="ctrl-x:execute-silent(tmux kill-session -t {2})+reload($self --list)")
 

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -14,10 +14,10 @@ prefixes_re="$(provider_prefixes_regex)"
 emit_rows() {
   local now s state at path icon rank ago provider
   now=$(date +%s)
-  tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E "^(${prefixes_re})" | while IFS= read -r s; do
-    state=$(tmux show-options -qv -t "$s" @claude_state 2>/dev/null)
-    at=$(tmux show-options -qv -t "$s" @claude_state_at 2>/dev/null)
-    path=$(tmux display-message -p -t "$s" '#{pane_current_path}' 2>/dev/null)
+  # One tmux call pulls every session's name, state, timestamp and path at once.
+  # Session-scoped user options are read inline via #{@claude_state} etc., so we
+  # avoid the previous per-session show-options/display-message subprocess fan-out.
+  while IFS=$'\t' read -r s state at path; do
     provider=$(provider_label "$(provider_of_session "$s")")
     case "$state" in
       waiting) icon=$'\033[33m●\033[0m waiting' rank=0 ;; # yellow - needs input
@@ -28,7 +28,10 @@ emit_rows() {
     if [ -n "$at" ]; then ago="$(( (now - at) / 60 ))m"; else ago='-'; fi
     # rank \t session \t provider \t icon \t path \t age  (rank/session hidden via --with-nth)
     printf '%s\t%s\t%-9s\t%s\t%s\t%s\n' "$rank" "$s" "$provider" "$icon" "${path/#$HOME/~}" "$ago"
-  done | sort -n # attention-needed (waiting, idle) float to the top
+  done < <(tmux list-sessions \
+             -F "#{session_name}	#{@claude_state}	#{@claude_state_at}	#{pane_current_path}" \
+             2>/dev/null | grep -E "^(${prefixes_re})") |
+    sort -n # attention-needed (waiting, idle) float to the top
 }
 
 [ "${1:-}" = '--list' ] && { emit_rows; exit 0; }

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -42,10 +42,35 @@ if ! command -v fzf >/dev/null 2>&1; then
 fi
 
 self="${BASH_SOURCE[0]}"
-sel=$(emit_rows | fzf --ansi --delimiter='\t' --with-nth=3,4,5,6 \
-  --reverse --cycle --header='AI sessions · enter: jump · ctrl-x: kill' \
-  --preview="tmux capture-pane -ept {2}" --preview-window='right,62%,wrap' \
-  --bind="ctrl-x:execute-silent(tmux kill-session -t {2})+reload($self --list)")
+
+# Base options shared by every fzf version.
+fzf_opts=(
+  --ansi --delimiter='\t' --with-nth=3,4,5,6
+  --reverse --cycle
+  --preview="tmux capture-pane -ept {2}"
+  --preview-window='right,70%,wrap'  # 3/7 split: list 30% · preview 70%
+  --bind="ctrl-x:execute-silent(tmux kill-session -t {2})+reload($self --list)"
+)
+
+# Bordered, multi-pane layout (fzf >= 0.53). Each region gets its own labelled
+# box — input, results list, preview — mirroring the lazy.nvim help viewer.
+# Older fzf lacks these flags, so fall back to a plain header + preview split.
+if fzf --help 2>&1 | grep -q -- '--list-border'; then
+  fzf_opts+=(
+    --style=full
+    --input-border   --input-label=' AI sessions '
+    --list-border    --list-label=' Results '
+    --preview-border --preview-label=' Preview '
+    --color='label:bold'
+    --pointer='▶'
+    --prompt='  '
+    --header='enter: jump · ctrl-x: kill'
+  )
+else
+  fzf_opts+=(--header='AI sessions · enter: jump · ctrl-x: kill')
+fi
+
+sel=$(emit_rows | fzf "${fzf_opts[@]}")
 
 [ -z "$sel" ] && exit 0
 target=$(printf '%s' "$sel" | cut -f2)

--- a/scripts/state.sh
+++ b/scripts/state.sh
@@ -9,6 +9,6 @@
 session=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}' 2>/dev/null) || exit 0
 [ -z "$session" ] && exit 0
 
-tmux set-option -t "$session" @claude_state "${1:-idle}"
-tmux set-option -t "$session" @claude_state_at "$(date +%s)"
+tmux set-option -t "$session" @ai_state "${1:-idle}"
+tmux set-option -t "$session" @ai_state_at "$(date +%s)"
 exit 0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Self-contained unit tests for the pure helpers in scripts/helpers.sh.
+# No external dependencies (no bats): tmux is stubbed so behaviour is
+# deterministic. Run:  ./tests/run.sh
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# --- tmux stub -------------------------------------------------------------
+# Reads option values from the TMUX_OPTS associative array; everything else is
+# a no-op returning non-zero so defaults kick in. Tests populate TMUX_OPTS.
+declare -A TMUX_OPTS=()
+tmux() {
+  if [ "${1:-}" = show-option ]; then
+    # show-option -gqv <name>  -> $3 is the name
+    printf '%s' "${TMUX_OPTS[$3]-}"
+    return 0
+  fi
+  return 1
+}
+export -f tmux
+
+# shellcheck source=../scripts/helpers.sh
+. "$ROOT/scripts/helpers.sh"
+
+# --- tiny assertion harness ------------------------------------------------
+pass=0 fail=0
+check() { # check <description> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'FAIL: %s\n  expected: [%s]\n  actual:   [%s]\n' "$1" "$2" "$3"
+  fi
+}
+
+# --- tests -----------------------------------------------------------------
+# provider_prefix / provider_of_session round-trip
+check 'provider_prefix claude' 'claude-' "$(provider_prefix claude)"
+check 'provider_of_session claude' 'claude' "$(provider_of_session claude-ab12cd34)"
+check 'provider_of_session opencode' 'opencode' "$(provider_of_session opencode-99887766)"
+
+# provider_prefixes_regex from defaults
+check 'prefixes_regex defaults' 'claude-|codex-|opencode-' "$(provider_prefixes_regex)"
+
+# provider_label from default list
+check 'label codex' 'Codex' "$(provider_label codex)"
+check 'label unknown -> key' 'gemini' "$(provider_label gemini)"
+
+# provider_command resolution order
+TMUX_OPTS=()
+check 'cmd from list' 'opencode' "$(provider_command opencode)"
+check 'cmd unknown -> key' 'gemini' "$(provider_command gemini)"
+
+TMUX_OPTS[@claude_command]='claude --resume'
+check 'cmd legacy override (claude only)' 'claude --resume' "$(provider_command claude)"
+check 'cmd legacy does not leak to codex' 'codex' "$(provider_command codex)"
+
+TMUX_OPTS[@claude_cmd_codex]='codex --model o1'
+check 'cmd per-provider with flags' 'codex --model o1' "$(provider_command codex)"
+TMUX_OPTS[@claude_cmd_claude]='claude --dangerously-skip-permissions'
+check 'cmd per-provider beats legacy' 'claude --dangerously-skip-permissions' "$(provider_command claude)"
+
+# custom @claude_providers
+TMUX_OPTS=([@claude_providers]='claude:claude:Claude gemini:gemini:Gemini')
+check 'custom providers regex' 'claude-|gemini-' "$(provider_prefixes_regex)"
+check 'custom providers label' 'Gemini' "$(provider_label gemini)"
+
+# popup_dims defaults and overrides
+TMUX_OPTS=()
+check 'popup_dims defaults' '90% 90%' "$(popup_dims)"
+TMUX_OPTS=([@claude_popup_width]='70%' [@claude_popup_height]='80%')
+check 'popup_dims overrides' '70% 80%' "$(popup_dims)"
+
+# session_hash: stable 8-char, deterministic
+h1="$(session_hash /home/me/project)"
+h2="$(session_hash /home/me/project)"
+check 'session_hash length 8' '8' "${#h1}"
+check 'session_hash deterministic' "$h1" "$h2"
+
+# --- summary ---------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -83,6 +83,14 @@ check '@ai_* takes precedence over @claude_*' 'claude --new' "$(provider_command
 TMUX_OPTS=([@claude_popup_width]='50%')
 check 'legacy @claude_popup_width alias' '50% 90%' "$(popup_dims)"
 
+# @ai_picker_opts escape hatch: empty default, resolves @ai_* then @claude_*
+TMUX_OPTS=()
+check 'picker_opts default empty' '' "$(get_opt picker_opts '')"
+TMUX_OPTS=([@ai_picker_opts]='--info=inline --color=label:6')
+check 'picker_opts @ai_*' '--info=inline --color=label:6' "$(get_opt picker_opts '')"
+TMUX_OPTS=([@claude_picker_opts]='--info=hidden')
+check 'picker_opts legacy alias' '--info=hidden' "$(get_opt picker_opts '')"
+
 # session_hash: stable 8-char, deterministic
 h1="$(session_hash /home/me/project)"
 h2="$(session_hash /home/me/project)"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -51,25 +51,37 @@ TMUX_OPTS=()
 check 'cmd from list' 'opencode' "$(provider_command opencode)"
 check 'cmd unknown -> key' 'gemini' "$(provider_command gemini)"
 
-TMUX_OPTS[@claude_command]='claude --resume'
-check 'cmd legacy override (claude only)' 'claude --resume' "$(provider_command claude)"
-check 'cmd legacy does not leak to codex' 'codex' "$(provider_command codex)"
+TMUX_OPTS[@ai_command]='claude --resume'
+check 'cmd override (claude only)' 'claude --resume' "$(provider_command claude)"
+check 'cmd override does not leak to codex' 'codex' "$(provider_command codex)"
 
-TMUX_OPTS[@claude_cmd_codex]='codex --model o1'
+TMUX_OPTS[@ai_cmd_codex]='codex --model o1'
 check 'cmd per-provider with flags' 'codex --model o1' "$(provider_command codex)"
-TMUX_OPTS[@claude_cmd_claude]='claude --dangerously-skip-permissions'
-check 'cmd per-provider beats legacy' 'claude --dangerously-skip-permissions' "$(provider_command claude)"
+TMUX_OPTS[@ai_cmd_claude]='claude --dangerously-skip-permissions'
+check 'cmd per-provider beats command override' 'claude --dangerously-skip-permissions' "$(provider_command claude)"
 
-# custom @claude_providers
-TMUX_OPTS=([@claude_providers]='claude:claude:Claude gemini:gemini:Gemini')
+# custom @ai_providers
+TMUX_OPTS=([@ai_providers]='claude:claude:Claude gemini:gemini:Gemini')
 check 'custom providers regex' 'claude-|gemini-' "$(provider_prefixes_regex)"
 check 'custom providers label' 'Gemini' "$(provider_label gemini)"
 
 # popup_dims defaults and overrides
 TMUX_OPTS=()
 check 'popup_dims defaults' '90% 90%' "$(popup_dims)"
-TMUX_OPTS=([@claude_popup_width]='70%' [@claude_popup_height]='80%')
+TMUX_OPTS=([@ai_popup_width]='70%' [@ai_popup_height]='80%')
 check 'popup_dims overrides' '70% 80%' "$(popup_dims)"
+
+# back-compat: deprecated @claude_* aliases still resolve, and @ai_* wins
+TMUX_OPTS=([@claude_providers]='claude:claude:Claude gemini:gemini:Gemini')
+check 'legacy @claude_providers alias' 'claude-|gemini-' "$(provider_prefixes_regex)"
+TMUX_OPTS=([@claude_command]='claude --legacy')
+check 'legacy @claude_command alias' 'claude --legacy' "$(provider_command claude)"
+TMUX_OPTS=([@claude_cmd_codex]='codex --legacy')
+check 'legacy @claude_cmd_<key> alias' 'codex --legacy' "$(provider_command codex)"
+TMUX_OPTS=([@ai_command]='claude --new' [@claude_command]='claude --old')
+check '@ai_* takes precedence over @claude_*' 'claude --new' "$(provider_command claude)"
+TMUX_OPTS=([@claude_popup_width]='50%')
+check 'legacy @claude_popup_width alias' '50% 90%' "$(popup_dims)"
 
 # session_hash: stable 8-char, deterministic
 h1="$(session_hash /home/me/project)"


### PR DESCRIPTION
Hi @craftzdog! 👋

First off — thank you for this plugin. The "one Claude session per project, jump
between them from a single popup" idea is exactly how I want to work, and it
quickly became part of my daily tmux setup. You're a big inspiration for me, so
contributing back here means a lot. 🙏

While using it across a few projects I started reaching for a couple of things,
built them on top of your design, and would love to share them upstream. Totally
understand if you only want some of it — I'm happy to split this into smaller PRs
or drop pieces (see the notes at the bottom).

## What's in here

**AI provider menu (the headline feature)**
- `prefix` + `Y` opens a `display-menu` to launch Claude, **Codex**, or
  **OpenCode** for the current directory. `prefix` + `y` still launches Claude
  directly, so existing muscle memory is unchanged.
- Providers are configurable via `@ai_providers` (`key:command:Label` entries).
  Each provider gets its own session prefix (`claude-`, `codex-`, `opencode-`),
  so the same directory can hold one session per provider without collisions.
- `@ai_cmd_<key>` lets a provider run with arguments (e.g.
  `codex --model o1`), since the providers list is space-delimited.
- The launcher now checks `command -v` before creating a session, so a missing
  CLI shows a tmux message instead of spawning a session that dies instantly.

**Picker**
- Lists sessions across all providers, with a provider column.
- Collapses the per-session `show-options`/`display-message` calls into a single
  `list-sessions -F` so it scales flat with session count.
- Optional bordered, multi-pane layout (input / results / preview) via fzf
  `--style=full` with a 3/7 list/preview split, feature-detected so older fzf
  falls back gracefully. `--height=100%` keeps it filling the popup even when
  `FZF_DEFAULT_OPTS` sets a smaller `--height`.
- `@ai_picker_opts` is an escape hatch for users to append their own fzf flags
  without editing the script.

**Smoother popup transitions**
- Opening the picker from inside a session popup no longer detaches + polls
  before reopening; it switches in place so there's no flash of the underlying
  session.

**Housekeeping**
- A small dependency-free unit-test suite for the pure helpers (`./tests/run.sh`,
  tmux stubbed) covering provider resolution, prefixes, labels and back-compat.
- README updated throughout.

## Back-compat

One commit renames the option namespace `@claude_*` → `@ai_*` (the plugin became
multi-provider, so `@claude_*` felt narrow). **Every option still accepts its old
`@claude_*` spelling via an alias resolver**, so existing configs keep working —
`@ai_*` is just canonical and wins when both are set.

## Honest notes for review

- The smoother (flash-free) popup behavior is the hardest part to unit-test —
  I've verified it manually on **tmux 3.6b / fzf 0.73**, but it touches nested
  popups + `switch-client`, so it deserves a careful look on other setups. If
  you'd rather not take that part, it's isolated in the last few `perf(picker)`
  commits.
- If you'd prefer to keep the `@claude_*` namespace, I can drop the rename commit
  and rebase the rest onto it — just say the word.

Either way, thanks for building this and for the inspiration. Happy to iterate on
anything! 🙇

🤖 Generated with [Claude Code](https://claude.com/claude-code)
