### PR TITLE
Add an AI provider menu (Claude / Codex / OpenCode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ run-shell ~/clone/path/claude_session_manager.tmux
 | Key            | Action                                                                          |
 | -------------- | ------------------------------------------------------------------------------- |
 | `prefix` + `y` | Launch (or re-attach to) a Claude session for the current directory, in a popup |
-| `prefix` + `u` | Open the session picker                                                         |
+| `prefix` + `Y` | Open the **AI provider menu** and launch the chosen provider for the directory  |
+| `prefix` + `u` | Open the session picker                                                          |
 
 Inside the picker:
 
@@ -151,22 +152,45 @@ The state machine:
 Set any of these before the plugin loads (defaults shown):
 
 ```tmux
-set -g @claude_launch_key     'y'        # prefix key: launch/open for current dir
-set -g @claude_list_key       'u'        # prefix key: open the picker
-set -g @claude_command        'claude'   # command run in new sessions
-set -g @claude_session_prefix 'claude-'  # tmux session name prefix
-set -g @claude_popup_width     '90%'     # popup width
-set -g @claude_popup_height    '90%'     # popup height
+set -g @claude_launch_key      'y'        # prefix key: launch/open Claude for current dir
+set -g @claude_launch_menu_key 'Y'        # prefix key: open the AI provider menu
+set -g @claude_list_key        'u'        # prefix key: open the picker
+set -g @claude_command         'claude'   # command for the claude provider (override)
+set -g @claude_popup_width      '90%'     # popup width
+set -g @claude_popup_height     '90%'     # popup height
+```
+
+### Multiple AI providers (optional)
+
+`prefix` + `Y` opens a menu to launch Claude, [Codex](https://github.com/openai/codex),
+[OpenCode](https://github.com/sst/opencode), or anything else you configure.
+Providers are listed in `@claude_providers` as space-separated `key:command:Label`
+entries — the default is just Claude, so nothing changes until you opt in:
+
+```tmux
+set -g @claude_providers 'claude:claude:Claude codex:codex:Codex opencode:opencode:OpenCode'
+```
+
+Each provider gets its own session prefix from its key (`claude-`, `codex-`,
+`opencode-`), so the same directory can hold one session per provider without
+collisions, and the picker lists them all with a provider column. To launch a
+provider with arguments (the list is space-delimited, so its command field can't
+hold them), use the per-provider `@claude_cmd_<key>` option:
+
+```tmux
+set -g @claude_cmd_codex 'codex --model o1'
 ```
 
 ## How it works
 
-- The **launcher** creates a detached `claude-<hash-of-dir>` tmux session running
-  `claude`, records the window it came from in `@claude_origin`, and attaches to
-  it in a popup.
+- The **launcher** creates a detached `<provider>-<hash-of-dir>` tmux session
+  running that provider's command (e.g. `claude-<hash>` running `claude`), records
+  the window it came from in `@claude_origin`, and attaches to it in a popup.
+- The **provider menu** (`prefix` + `Y`) is built from `@claude_providers`; each
+  entry launches via the same launcher with its own command and session prefix.
 - The **hooks** set `@claude_state` / `@claude_state_at` on each session as Claude
   works.
-- The **picker** lists sessions matching the prefix, reads their state and a live
+- The **picker** lists sessions matching any provider prefix, reads their state and a live
   `capture-pane` preview, and on selection moves your client to the session's
   origin window before resuming it in the popup.
 - Pressing `prefix` + `u` **from inside a session popup** detaches that popup

--- a/claude_session_manager.tmux
+++ b/claude_session_manager.tmux
@@ -10,13 +10,29 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$CURRENT_DIR/scripts/helpers.sh"
 
 launch_key="$(get_tmux_option @claude_launch_key 'y')"
+launch_menu_key="$(get_tmux_option @claude_launch_menu_key 'Y')"
 list_key="$(get_tmux_option @claude_list_key 'u')"
 
 # Launch (or re-attach to) a Claude session for the current pane's directory.
 # #{pane_current_path} / #{window_id} are expanded by run-shell before the args
 # reach the script.
 tmux bind-key "$launch_key" \
-  run-shell "$CURRENT_DIR/scripts/launch.sh '#{pane_current_path}' '#{window_id}'"
+  run-shell "$CURRENT_DIR/scripts/launch.sh '#{pane_current_path}' '#{window_id}' claude"
+
+# Provider menu: pick which AI CLI to launch for the current pane's directory.
+# Built from @claude_providers; each entry gets a numeric shortcut (1, 2, 3, …).
+# With the default single-provider list this just launches Claude.
+menu_args=()
+i=0
+for entry in $(get_providers); do
+  i=$((i + 1))
+  IFS=: read -r key _ label <<<"$entry"
+  [ -z "$label" ] && label="$key"
+  menu_args+=("$label" "$i" \
+    "run-shell \"$CURRENT_DIR/scripts/launch.sh '#{pane_current_path}' '#{window_id}' $key\"")
+done
+tmux bind-key "$launch_menu_key" \
+  display-menu -T ' AI Provider ' -x C -y C "${menu_args[@]}"
 
 # Open the session picker. When pressed from inside a session popup, list.sh
 # closes that popup first so the picker opens full-size on the outer client.

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -13,6 +13,80 @@ get_tmux_option() {
   fi
 }
 
+# ---------------------------------------------------------------------------
+# AI providers
+#
+# A provider is one launchable AI CLI (Claude, Codex, OpenCode, ...). The set is
+# configurable via the @claude_providers tmux option as a space-separated list
+# of  key:command:Label  entries:
+#
+#   set -g @claude_providers 'claude:claude:Claude codex:codex:Codex'
+#
+# - key     identifies the provider and forms its session prefix ("claude-").
+# - command is what runs inside the session (defaults to key when omitted).
+# - Label   is shown in the launch menu and picker (defaults to key).
+#
+# Defaulting to just "claude" keeps behavior identical for users who never set
+# the option; add codex/opencode/etc. to opt into the multi-provider menu.
+# ---------------------------------------------------------------------------
+default_providers='claude:claude:Claude'
+
+get_providers() {
+  get_tmux_option @claude_providers "$default_providers"
+}
+
+# provider_prefix <key> -> session-name prefix, e.g. "claude-"
+provider_prefix() { printf '%s-' "$1"; }
+
+# provider_command <key> -> command to run for that provider.
+# Resolution order (first non-empty wins):
+#   1. @claude_cmd_<key>  per-provider option, may contain spaces/flags, e.g.
+#                         set -g @claude_cmd_codex 'codex --model o1'
+#   2. @claude_command    override for the claude provider (back-compat)
+#   3. the command field of the @claude_providers entry (no spaces — see header)
+#   4. the key itself
+# The per-provider option exists because @claude_providers is space-delimited and
+# therefore cannot carry a command with arguments; this option can.
+provider_command() {
+  local want="$1" entry key command override
+  override="$(tmux show-option -gqv "@claude_cmd_${want}" 2>/dev/null)"
+  [ -n "$override" ] && { printf '%s' "$override"; return; }
+  if [ "$want" = claude ]; then
+    override="$(tmux show-option -gqv @claude_command 2>/dev/null)"
+    [ -n "$override" ] && { printf '%s' "$override"; return; }
+  fi
+  for entry in $(get_providers); do
+    IFS=: read -r key command _ <<<"$entry"
+    [ "$key" = "$want" ] && { printf '%s' "${command:-$key}"; return; }
+  done
+  printf '%s' "$want"
+}
+
+# provider_of_session <session-name> -> provider key (text before the hash).
+# Session names are "<key>-<8charhash>" and keys contain no dash.
+provider_of_session() { printf '%s' "${1%-*}"; }
+
+# provider_label <key> -> human label from the providers list (defaults to key).
+provider_label() {
+  local want="$1" entry key label
+  for entry in $(get_providers); do
+    IFS=: read -r key _ label <<<"$entry"
+    [ "$key" = "$want" ] && { printf '%s' "${label:-$key}"; return; }
+  done
+  printf '%s' "$want"
+}
+
+# provider_prefixes_regex -> alternation of every provider prefix, e.g.
+# "claude-|codex-|opencode-" for anchoring grep/awk matches.
+provider_prefixes_regex() {
+  local entry key out=''
+  for entry in $(get_providers); do
+    IFS=: read -r key _ _ <<<"$entry"
+    out="${out}${out:+|}$(provider_prefix "$key")"
+  done
+  printf '%s' "$out"
+}
+
 # session_hash <string>
 # Short, stable, portable 8-char hash for deriving a session name from a path.
 # Prefers md5sum (Linux), falls back to md5 (macOS) then shasum. The trailing

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Launch (or re-attach to) a Claude session for a directory, shown in a popup.
-# Args: <dir> [origin-window-id]   (both expanded by run-shell in the binding)
+# Launch (or re-attach to) an AI session for a directory, shown in a popup.
+# Args: <dir> [origin-window-id] [provider]
+#   dir/window are expanded by run-shell in the binding; provider defaults to
+#   'claude' so the plain prefix+y binding behaves exactly as before.
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
@@ -8,21 +10,31 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 path="${1:-$PWD}"
 window="${2:-}"
+provider="${3:-claude}"
 
-prefix="$(get_tmux_option @claude_session_prefix 'claude-')"
-cmd="$(get_tmux_option @claude_command 'claude')"
+prefix="$(provider_prefix "$provider")"
+cmd="$(provider_command "$provider")"
 w="$(get_tmux_option @claude_popup_width '90%')"
 h="$(get_tmux_option @claude_popup_height '90%')"
 
 session="${prefix}$(session_hash "$path")"
 
-if [[ "$(tmux display-message -p '#S')" == "$prefix"* ]]; then
+# Don't open a popup while already inside one of our session popups (any
+# provider). tmux can't nest popups cleanly, so refuse and tell the user.
+if printf '%s' "$(tmux display-message -p '#S')" | grep -qE "^($(provider_prefixes_regex))"; then
   tmux display-message '🫪 Popup window already open'
   exit 0
 fi
 
-tmux has-session -t "$session" 2>/dev/null ||
+if ! tmux has-session -t "$session" 2>/dev/null; then
+  # Fail loudly instead of spawning a session that dies instantly when the
+  # provider CLI is missing. ${cmd%% *} strips arguments so we test the binary.
+  if ! command -v "${cmd%% *}" >/dev/null 2>&1; then
+    tmux display-message "tmux-claude-session-manager: '${cmd%% *}' not found in PATH"
+    exit 0
+  fi
   tmux new-session -d -s "$session" -c "$path" "$cmd"
+fi
 
 # Record which window launched it, so the picker can jump back here later.
 [ -n "$window" ] && tmux set-option -t "$session" @claude_origin "$window"

--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -5,22 +5,22 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
 . "$DIR/helpers.sh"
 
-prefix="$(get_tmux_option @claude_session_prefix 'claude-')"
+prefixes_re="^($(provider_prefixes_regex))"
 w="$(get_tmux_option @claude_popup_width '90%')"
 h="$(get_tmux_option @claude_popup_height '90%')"
 
-# The session of a client attached to a prefixed session — i.e. the popup we are
-# inside, if any. Empty when invoked from a normal (non-popup) pane.
+# The session of a client attached to a managed (provider-prefixed) session —
+# i.e. the popup we are inside, if any. Empty when invoked from a normal pane.
 nested_session() {
   tmux list-clients -F '#{client_name} #{session_name}' 2>/dev/null |
-    awk -v p="$prefix" 'index($2, p) == 1 { print $2; exit }'
+    awk -v re="$prefixes_re" '$2 ~ re { print $2; exit }'
 }
 
-# A client NOT attached to a prefixed session — the outer client that should host
+# A client NOT attached to a managed session — the outer client that should host
 # the picker popup.
 host_client() {
   tmux list-clients -F '#{client_name} #{session_name}' 2>/dev/null |
-    awk -v p="$prefix" 'index($2, p) != 1 { print $1; exit }'
+    awk -v re="$prefixes_re" '$2 !~ re { print $1; exit }'
 }
 
 # If we are inside a session popup, close it (detach its client)

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Interactive picker for running Claude sessions.
+# Interactive picker for running AI sessions (across all configured providers).
 #
 #   picker.sh           fzf picker; on enter, switches the parent client to the
 #                       chosen session's origin window and resumes it in the popup.
@@ -9,15 +9,16 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
 . "$DIR/helpers.sh"
 
-prefix="$(get_tmux_option @claude_session_prefix 'claude-')"
+prefixes_re="$(provider_prefixes_regex)"
 
 emit_rows() {
-  local now s state at path icon rank ago
+  local now s state at path icon rank ago provider
   now=$(date +%s)
-  tmux list-sessions -F '#{session_name}' 2>/dev/null | grep "^${prefix}" | while IFS= read -r s; do
+  tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E "^(${prefixes_re})" | while IFS= read -r s; do
     state=$(tmux show-options -qv -t "$s" @claude_state 2>/dev/null)
     at=$(tmux show-options -qv -t "$s" @claude_state_at 2>/dev/null)
     path=$(tmux display-message -p -t "$s" '#{pane_current_path}' 2>/dev/null)
+    provider=$(provider_label "$(provider_of_session "$s")")
     case "$state" in
     waiting) icon=$'\033[33m●\033[0m waiting' rank=0 ;; # yellow - needs input
     idle) icon=$'\033[32m●\033[0m idle   ' rank=1 ;;    # green  - done, your turn
@@ -25,12 +26,12 @@ emit_rows() {
     *) icon=$'\033[90m●\033[0m   ?    ' rank=2 ;;       # grey   - unknown (no hook yet)
     esac
     if [ -n "$at" ]; then ago="$(((now - at) / 60))m"; else ago='-'; fi
-    # rank \t session \t icon \t age \t path   (rank/session hidden via --with-nth)
-    printf '%s\t%s\t%s\t%5s\t%s\n' "$rank" "$s" "$icon" "$ago" "${path/#$HOME/~}"
+    # rank \t session \t provider \t icon \t age \t path  (rank/session hidden via --with-nth)
+    printf '%s\t%s\t%-9s\t%s\t%5s\t%s\n' "$rank" "$s" "$provider" "$icon" "$ago" "${path/#$HOME/~}"
     # rank asc (attention-needed floats up), then age asc so the session that
-    # finished just now sits at the top of its group. -k4,4n reads the leading
+    # finished just now sits at the top of its group. -k5,5n reads the leading
     # number of the age field ("5m" -> 5; "-" -> 0).
-  done | sort -t$'\t' -k1,1n -k4,4n
+  done | sort -t$'\t' -k1,1n -k5,5n
 }
 
 [ "${1:-}" = '--list' ] && {
@@ -45,8 +46,8 @@ fi
 
 self="${BASH_SOURCE[0]}"
 export FZF_DEFAULT_OPTS=''
-sel=$(emit_rows | fzf --ansi --delimiter='\t' --with-nth=3,4,5 \
-  --reverse --cycle --header='Claude sessions · enter: jump · ctrl-x: kill' \
+sel=$(emit_rows | fzf --ansi --delimiter='\t' --with-nth=3,4,5,6 \
+  --reverse --cycle --header='AI sessions · enter: jump · ctrl-x: kill' \
   --preview="tmux capture-pane -ept {2}" --preview-window='right,62%,wrap' \
   --bind="ctrl-x:execute-silent(tmux kill-session -t {2})+reload($self --list)")
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Self-contained unit tests for the pure helpers in scripts/helpers.sh.
+# No external dependencies (no bats): tmux is stubbed so behaviour is
+# deterministic. Run:  ./tests/run.sh
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# --- tmux stub -------------------------------------------------------------
+# Reads option values from TMUX_OPTS; everything else is a no-op returning
+# non-zero so defaults kick in. Tests populate TMUX_OPTS.
+declare -A TMUX_OPTS=()
+tmux() {
+  if [ "${1:-}" = show-option ]; then
+    printf '%s' "${TMUX_OPTS[$3]-}" # show-option -gqv <name>  -> $3 is the name
+    return 0
+  fi
+  return 1
+}
+export -f tmux
+
+# shellcheck source=../scripts/helpers.sh
+. "$ROOT/scripts/helpers.sh"
+
+# --- tiny assertion harness ------------------------------------------------
+pass=0 fail=0
+check() { # check <description> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'FAIL: %s\n  expected: [%s]\n  actual:   [%s]\n' "$1" "$2" "$3"
+  fi
+}
+
+# --- tests -----------------------------------------------------------------
+# Default provider list is just claude (opt-in to more via @claude_providers).
+check 'default providers' 'claude:claude:Claude' "$(get_providers)"
+check 'default prefixes_regex' 'claude-' "$(provider_prefixes_regex)"
+
+# provider_prefix / provider_of_session round-trip
+check 'provider_prefix claude' 'claude-' "$(provider_prefix claude)"
+check 'provider_of_session claude' 'claude' "$(provider_of_session claude-ab12cd34)"
+check 'provider_of_session opencode' 'opencode' "$(provider_of_session opencode-99887766)"
+
+# Custom provider list
+TMUX_OPTS=([@claude_providers]='claude:claude:Claude codex:codex:Codex opencode:opencode:OpenCode')
+check 'custom prefixes_regex' 'claude-|codex-|opencode-' "$(provider_prefixes_regex)"
+check 'label codex' 'Codex' "$(provider_label codex)"
+check 'label unknown -> key' 'gemini' "$(provider_label gemini)"
+
+# provider_command resolution order
+check 'cmd from list' 'opencode' "$(provider_command opencode)"
+check 'cmd unknown -> key' 'gemini' "$(provider_command gemini)"
+
+TMUX_OPTS[@claude_command]='claude --resume'
+check 'cmd @claude_command (claude only)' 'claude --resume' "$(provider_command claude)"
+check 'cmd override does not leak to codex' 'codex' "$(provider_command codex)"
+
+TMUX_OPTS[@claude_cmd_codex]='codex --model o1'
+check 'cmd per-provider with flags' 'codex --model o1' "$(provider_command codex)"
+TMUX_OPTS[@claude_cmd_claude]='claude --dangerously-skip-permissions'
+check 'cmd per-provider beats @claude_command' 'claude --dangerously-skip-permissions' "$(provider_command claude)"
+
+# Label/command default when the entry omits them
+TMUX_OPTS=([@claude_providers]='gemini')
+check 'bare entry label -> key' 'gemini' "$(provider_label gemini)"
+check 'bare entry command -> key' 'gemini' "$(provider_command gemini)"
+
+# session_hash: stable 8-char, deterministic
+h1="$(session_hash /home/me/project)"
+h2="$(session_hash /home/me/project)"
+check 'session_hash length 8' '8' "${#h1}"
+check 'session_hash deterministic' "$h1" "$h2"
+
+# --- summary ---------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Hi @craftzdog! 👋

Thank you for this plugin — the "one Claude session per project, jump between
them from a single popup" workflow is exactly how I like to work, and it's become
part of my daily tmux setup. You're a big inspiration for me, so contributing
back here means a lot. 🙏

While using it I started wanting to launch **other AI CLIs** (Codex, OpenCode)
the same way, so I built a small provider menu on top of your design and would
love to share it. I kept everything aligned with your conventions — same
`@claude_*` namespace, the hermetic `FZF_DEFAULT_OPTS` reset, and your
no-nested-popup launch guard — so it should slot in without changing existing
behavior.

## What's in here

- **`prefix` + `Y` opens an AI provider menu** to launch Claude, **Codex**,
  **OpenCode**, or anything else you configure, for the current directory.
  `prefix` + `y` still launches Claude directly.
- **Configurable providers** via `@claude_providers` (`key:command:Label`
  entries). Each provider gets its own session prefix (`claude-`, `codex-`,
  `opencode-`), so a directory can hold one session per provider without
  collisions, and the **picker lists them all with a provider column**.
- **`@claude_cmd_<key>`** lets a provider run with arguments (e.g.
  `codex --model o1`), since the providers list is space-delimited.
- The launcher **checks `command -v`** before creating a session, so a missing
  CLI shows a tmux message instead of spawning a session that dies instantly.
- A small **dependency-free unit-test suite** for the pure helpers
  (`./tests/run.sh`, tmux stubbed).

## Compatibility

- **The default provider list is just Claude**, so nothing changes until a user
  opts in by setting `@claude_providers`.
- One small thing worth flagging: session prefixes are now derived per provider
  key, so the `@claude_session_prefix` option is no longer read. The default
  (`claude-`) is identical, so it only affects anyone who customized that option
  — happy to add a shim for it if you'd like to keep it.

Totally understand if you'd like changes, a different shape, or only part of
this — just let me know and I'll iterate. Thanks again for building this and for
the inspiration! 🙇

🤖 Generated with [Claude Code](https://claude.com/claude-code)
