### PR TITLE
feat(picker): add @claude_scope to track Claude running in arbitrary panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ each one. This plugin gives you:
 - 🚀 **A launcher** (`prefix` + `y`) that opens/attaches a Claude session for the
   current directory.
 - ❌ **Quick kill** (`ctrl-x`) of finished sessions from the picker.
+- 🪟 **Or track Claude in your own panes** — if you run Claude as a pane inside
+  your project sessions (several per session) rather than via the launcher, set
+  `@claude_scope 'pane'` and the picker lists those instead. See
+  [Scope](#scope-dedicated-sessions-vs-your-own-panes).
 
 Status is optional: without the hooks the picker still lists, previews, jumps,
 and kills — sessions just show `?` instead of a color.
@@ -155,20 +159,43 @@ set -g @claude_launch_key     'y'        # prefix key: launch/open for current d
 set -g @claude_list_key       'u'        # prefix key: open the picker
 set -g @claude_command        'claude'   # command run in new sessions
 set -g @claude_session_prefix 'claude-'  # tmux session name prefix
+set -g @claude_scope          'session'  # what the picker lists: session | pane | auto
 set -g @claude_popup_width     '90%'     # popup width
 set -g @claude_popup_height    '90%'     # popup height
 ```
+
+### Scope: dedicated sessions vs. your own panes
+
+By default the picker lists the dedicated `claude-*` sessions created by the
+launcher (`prefix` + `y`). If you instead run Claude as a **pane inside your own
+project sessions** — often several per session — set `@claude_scope`:
+
+| Value       | The picker lists…                                                                 |
+| ----------- | --------------------------------------------------------------------------------- |
+| `session`   | (default) dedicated `claude-*` sessions created by the launcher                   |
+| `pane`      | every pane whose foreground command is `claude`, across **all** tmux sessions     |
+| `auto`      | `session` if any `claude-*` session exists, otherwise `pane`                       |
+
+In `pane` scope, `enter` switches your client to that pane's session/window and
+focuses it (no popup overlay), and `ctrl-x` kills just that **pane** (not the
+whole session). Panes are matched against `@claude_command` (the basename), so if
+your Claude runs under a wrapper that shows up as a different command, set
+`@claude_command` to match.
 
 ## How it works
 
 - The **launcher** creates a detached `claude-<hash-of-dir>` tmux session running
   `claude`, records the window it came from in `@claude_origin`, and attaches to
   it in a popup.
-- The **hooks** set `@claude_state` / `@claude_state_at` on each session as Claude
-  works.
-- The **picker** lists sessions matching the prefix, reads their state and a live
-  `capture-pane` preview, and on selection moves your client to the session's
-  origin window before resuming it in the popup.
+- The **hooks** set `@claude_state` / `@claude_state_at` as Claude works — on both
+  the pane (via `set-option -p`) and its session. The per-pane copy lets several
+  Claude panes in one session track state independently; the per-session copy
+  keeps `session` scope working unchanged.
+- The **picker** lists sessions matching the prefix (or, in `pane` scope, panes
+  running `claude`), reads their state and a live `capture-pane` preview, and on
+  selection jumps to the chosen Claude — for sessions, moving your client to the
+  origin window and resuming in the popup; for panes, switching to the pane's
+  window and focusing it.
 - Pressing `prefix` + `u` **from inside a session popup** detaches that popup
   first (closing it), then reopens the picker full-size on the outer host client —
   so you never end up with a cramped popup-in-popup.

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -1,36 +1,81 @@
 #!/usr/bin/env bash
-# Interactive picker for running Claude sessions.
+# Interactive picker for running Claude sessions / panes.
 #
-#   picker.sh           fzf picker; on enter, switches the parent client to the
-#                       chosen session's origin window and resumes it in the popup.
+#   picker.sh           fzf picker; on enter, jumps to the chosen Claude.
 #   picker.sh --list    print the rows only (used by fzf's ctrl-x reload).
+#
+# Scope is controlled by @claude_scope (default 'session'):
+#   session  list dedicated `claude-*` sessions created by the launcher (prefix+y).
+#   pane     list every pane whose foreground command is the Claude CLI, across
+#            all tmux sessions (works when you run Claude as a pane in your own
+#            project sessions, several per session).
+#   auto     'session' if any `claude-*` session exists, otherwise 'pane'.
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
 . "$DIR/helpers.sh"
 
 prefix="$(get_tmux_option @claude_session_prefix 'claude-')"
+scope="$(get_tmux_option @claude_scope 'session')"
+cmd="$(get_tmux_option @claude_command 'claude')"
+# Foreground command name to match in pane scope: basename of @claude_command,
+# minus any arguments (e.g. '/opt/homebrew/bin/claude --foo' -> 'claude').
+cmd_base="${cmd##*/}"
+cmd_base="${cmd_base%% *}"
 
-emit_rows() {
+# Resolve 'auto' to a concrete scope: use dedicated-session view if the launcher
+# has created any `claude-*` sessions, otherwise fall back to scanning panes.
+if [ "$scope" = 'auto' ]; then
+  if tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -q "^${prefix}"; then
+    scope='session'
+  else
+    scope='pane'
+  fi
+fi
+
+# state_icon <state> -> sets globals `icon` and `rank` (shared by both scopes).
+state_icon() {
+  case "$1" in
+  waiting) icon=$'\033[33m●\033[0m waiting' rank=0 ;; # yellow - needs input
+  idle) icon=$'\033[32m●\033[0m idle   ' rank=1 ;;    # green  - done, your turn
+  working) icon=$'\033[31m●\033[0m working' rank=3 ;; # red    - busy, leave it
+  *) icon=$'\033[90m●\033[0m   ?    ' rank=2 ;;       # grey   - unknown (no hook yet)
+  esac
+}
+
+# rank asc (attention-needed floats up), then age asc so the one that finished
+# just now sits at the top of its group. -k4,4n reads the leading number of the
+# age field ("5m" -> 5; "-" -> 0).  Column 2 is the jump/preview/kill target.
+emit_rows_session() {
   local now s state at path icon rank ago
   now=$(date +%s)
   tmux list-sessions -F '#{session_name}' 2>/dev/null | grep "^${prefix}" | while IFS= read -r s; do
     state=$(tmux show-options -qv -t "$s" @claude_state 2>/dev/null)
     at=$(tmux show-options -qv -t "$s" @claude_state_at 2>/dev/null)
     path=$(tmux display-message -p -t "$s" '#{pane_current_path}' 2>/dev/null)
-    case "$state" in
-    waiting) icon=$'\033[33m●\033[0m waiting' rank=0 ;; # yellow - needs input
-    idle) icon=$'\033[32m●\033[0m idle   ' rank=1 ;;    # green  - done, your turn
-    working) icon=$'\033[31m●\033[0m working' rank=3 ;; # red    - busy, leave it
-    *) icon=$'\033[90m●\033[0m   ?    ' rank=2 ;;       # grey   - unknown (no hook yet)
-    esac
+    state_icon "$state"
     if [ -n "$at" ]; then ago="$(((now - at) / 60))m"; else ago='-'; fi
-    # rank \t session \t icon \t age \t path   (rank/session hidden via --with-nth)
     printf '%s\t%s\t%s\t%5s\t%s\n' "$rank" "$s" "$icon" "$ago" "${path/#$HOME/~}"
-    # rank asc (attention-needed floats up), then age asc so the session that
-    # finished just now sits at the top of its group. -k4,4n reads the leading
-    # number of the age field ("5m" -> 5; "-" -> 0).
   done | sort -t$'\t' -k1,1n -k4,4n
+}
+
+emit_rows_pane() {
+  local now pane sess win path state at icon rank ago
+  now=$(date +%s)
+  tmux list-panes -a -F '#{pane_id}	#{pane_current_command}	#{session_name}	#{window_index}	#{pane_current_path}' 2>/dev/null |
+    awk -F'\t' -v c="$cmd_base" '$2 == c { print $1 "\t" $3 "\t" $4 "\t" $5 }' |
+    while IFS=$'\t' read -r pane sess win path; do
+      state=$(tmux show-options -pqv -t "$pane" @claude_state 2>/dev/null)
+      at=$(tmux show-options -pqv -t "$pane" @claude_state_at 2>/dev/null)
+      state_icon "$state"
+      if [ -n "$at" ]; then ago="$(((now - at) / 60))m"; else ago='-'; fi
+      # target column is the pane id; label shows session:window + path
+      printf '%s\t%s\t%s\t%5s\t%s\n' "$rank" "$pane" "$icon" "$ago" "${sess}:${win}  ${path/#$HOME/~}"
+    done | sort -t$'\t' -k1,1n -k4,4n
+}
+
+emit_rows() {
+  if [ "$scope" = 'pane' ]; then emit_rows_pane; else emit_rows_session; fi
 }
 
 [ "${1:-}" = '--list' ] && {
@@ -43,21 +88,43 @@ if ! command -v fzf >/dev/null 2>&1; then
   exit 0
 fi
 
+if [ "$scope" = 'pane' ]; then
+  kill_cmd='tmux kill-pane -t {2}'
+  header='Claude panes · enter: jump · ctrl-x: kill'
+else
+  kill_cmd='tmux kill-session -t {2}'
+  header='Claude sessions · enter: jump · ctrl-x: kill'
+fi
+
 self="${BASH_SOURCE[0]}"
 export FZF_DEFAULT_OPTS=''
 sel=$(emit_rows | fzf --ansi --delimiter='\t' --with-nth=3,4,5 \
-  --reverse --cycle --header='Claude sessions · enter: jump · ctrl-x: kill' \
+  --reverse --cycle --header="$header" \
   --preview="tmux capture-pane -ept {2}" --preview-window='right,62%,wrap' \
-  --bind="ctrl-x:execute-silent(tmux kill-session -t {2})+reload($self --list)")
+  --bind="ctrl-x:execute-silent($kill_cmd)+reload($self --list)")
 
 [ -z "$sel" ] && exit 0
 target=$(printf '%s' "$sel" | cut -f2)
-
-# Move the underlying parent client to the session's origin window (best-effort),
-# then resume the session in THIS popup over it. Falls back to resuming over the
-# current window when origin/parent are unknown.
-origin=$(tmux show-options -qv -t "$target" @claude_origin 2>/dev/null)
 parent=$(tmux show-options -gqv @claude_parent 2>/dev/null)
+
+if [ "$scope" = 'pane' ]; then
+  # The target is a real pane in one of the user's sessions. Move the underlying
+  # parent client there (session:window), focus the pane, then let this popup
+  # close on exit. No attach — the pane already lives in a normal session.
+  dest=$(tmux display-message -p -t "$target" '#{session_name}:#{window_index}' 2>/dev/null)
+  if [ -n "$parent" ] && [ -n "$dest" ]; then
+    tmux switch-client -c "$parent" -t "$dest" 2>/dev/null
+  elif [ -n "$dest" ]; then
+    tmux switch-client -t "$dest" 2>/dev/null
+  fi
+  tmux select-pane -t "$target" 2>/dev/null
+  exit 0
+fi
+
+# session scope: move the underlying parent client to the session's origin window
+# (best-effort), then resume the session in THIS popup over it. Falls back to
+# resuming over the current window when origin/parent are unknown.
+origin=$(tmux show-options -qv -t "$target" @claude_origin 2>/dev/null)
 [ -n "$origin" ] && [ -n "$parent" ] &&
   tmux switch-client -c "$parent" -t "$origin" 2>/dev/null
 

--- a/scripts/state.sh
+++ b/scripts/state.sh
@@ -1,14 +1,28 @@
 #!/usr/bin/env bash
-# Record a Claude Code session's state on its tmux session, for the picker.
+# Record a Claude Code session's state for the picker.
 # Wire this into Claude Code hooks (see README):  state.sh <working|waiting|idle>
 #
 # Claude Code hooks inherit the Claude process environment, so $TMUX_PANE is set
 # whenever Claude runs inside tmux. Outside tmux this is a no-op.
+#
+# State is recorded twice, so both picker scopes work without extra config:
+#   - per-pane    (set -p): used by @claude_scope 'pane'/'auto'. Lets several
+#                 Claude panes in the SAME tmux session track state independently.
+#   - per-session: used by @claude_scope 'session' (default). Preserves the
+#                 original behavior for dedicated `claude-*` sessions (one pane).
 [ -z "$TMUX_PANE" ] && exit 0
 
-session=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}' 2>/dev/null) || exit 0
-[ -z "$session" ] && exit 0
+state="${1:-idle}"
+now="$(date +%s)"
 
-tmux set-option -t "$session" @claude_state "${1:-idle}"
-tmux set-option -t "$session" @claude_state_at "$(date +%s)"
+# per-pane
+tmux set-option -p -t "$TMUX_PANE" @claude_state "$state"
+tmux set-option -p -t "$TMUX_PANE" @claude_state_at "$now"
+
+# per-session (best-effort; harmless when several Claude panes share a session)
+session=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}' 2>/dev/null)
+if [ -n "$session" ]; then
+  tmux set-option -t "$session" @claude_state "$state"
+  tmux set-option -t "$session" @claude_state_at "$now"
+fi
 exit 0


### PR DESCRIPTION
## What

Adds an opt-in `@claude_scope` option so the picker can track Claude Code running as **panes inside your own project sessions**, not only the dedicated `claude-*` sessions created by the launcher.

| `@claude_scope` | The picker lists… |
| --- | --- |
| `session` (default) | dedicated `claude-*` sessions created by `prefix`+`y` — **unchanged** |
| `pane` | every pane whose foreground command matches `@claude_command`, across all sessions |
| `auto` | `session` if any `claude-*` session exists, otherwise `pane` |

## Why

Today the picker only knows about sessions the launcher spawned (`list-sessions | grep '^claude-'`). Many people run Claude as a pane next to their editor/shell inside a project session — often several Claudes per session. For that workflow the picker shows `0/0`. This generalises the plugin to "find Claude wherever it runs" without changing the default behavior.

## Design / backward compatibility

- Default stays `session` → existing behavior is byte-for-byte unchanged.
- `state.sh` now stamps state on the **pane** (`set-option -p`) in addition to the session. The per-pane copy lets multiple Claude panes in one session report status independently; the per-session copy keeps `session` scope working exactly as before. Hook wiring (the `state.sh working|waiting|idle` calls) is unchanged.
- In `pane` scope, `enter` switches the client to the pane's window and focuses it (no popup overlay); `ctrl-x` kills just that pane.
- Pane detection matches `@claude_command`'s basename against `#{pane_current_command}`. If Claude runs under a wrapper that reports a different command (e.g. `node`), set `@claude_command` to match — happy to add a dedicated match option if you'd prefer.

## Testing

- `@claude_scope session` (default): unchanged behavior; with no `claude-*` sessions the list is empty, no errors.
- `@claude_scope pane`: lists all panes running `claude` across multiple sessions, each with independent working/waiting/idle status from the hooks; `enter` jumps to the pane; `ctrl-x` kills the pane.
- `@claude_scope auto`: resolves to `session`/`pane` as documented.
- `bash -n` clean on all changed scripts; verified on tmux 3.6b (macOS).

