### PR TITLE
feat(picker): add pane-based discovery and fix picker popup client

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@
 [![screenshot](./docs/screenshot.jpg)](https://youtu.be/NnTV6r4l5D0)
 
 Run many [Claude Code](https://claude.com/claude-code) sessions across your
-projects, each in its own tmux session — then **list them, see which are done
-vs. still working, and jump to one** from a single popup.
+projects — then **list them, see which are done vs. still working, and jump to
+one** from a single popup.
 
-If you launch Claude per-directory (one nested session per project), you quickly
-end up with a dozen of them and no way to tell which are finished without opening
-each one. This plugin gives you:
+If you run Claude in lots of places, you quickly end up with a dozen of them and
+no way to tell which are finished without opening each one. This plugin gives
+you:
 
-- 🔢 **A central picker** (`prefix` + `u`) listing every running Claude session.
+- 🔢 **A central picker** (`prefix` + `u`) listing every running Claude session —
+  or, with [`pane` discovery](#discovery-modes), every pane running Claude,
+  however you started it.
 - 🟢 **Live status** per session — `working` / `waiting` / `idle` — driven by
   Claude Code hooks, so you instantly see which need you.
 - 👁️ **A live preview** of each session's screen right in the picker.
@@ -74,13 +76,33 @@ Inside the picker:
 
 Sessions needing your attention (`waiting`, `idle`) sort to the top.
 
+## Discovery modes
+
+`@claude_discover` controls **what the picker lists** (default `session`):
+
+- **`session`** — tmux sessions whose name starts with `@claude_session_prefix`
+  (`claude-`). This is the launcher model: each `prefix` + `y` creates one
+  `claude-<hash>` session. State is stamped per session, and `enter` resumes the
+  session in the popup.
+- **`pane`** — every tmux pane whose foreground command is `@claude_command`
+  (`claude`), **however it was started** — this plugin's launcher, a tmuxinator
+  layout, or a manual `claude` in any window or pane. State is stamped per pane,
+  so several Claudes sharing one session each report independently, and `enter`
+  switches your client to the pane's window and selects it.
+
+Pick pane discovery with:
+
+```tmux
+set -g @claude_discover 'pane'
+```
+
 ## Status setup (optional, recommended)
 
 Status comes from [Claude Code hooks](https://code.claude.com/docs/en/hooks)
-that stamp each session's state onto its tmux session. Add the following to your
-Claude Code settings (`~/.claude/settings.json`), merging into any existing
-`hooks` block. Adjust the path if your plugins live elsewhere (e.g.
-`~/.tmux/plugins/...`):
+that stamp each session's state onto its tmux session (or pane, with
+`@claude_discover 'pane'`). Add the following to your Claude Code settings
+(`~/.claude/settings.json`), merging into any existing `hooks` block. Adjust the
+path if your plugins live elsewhere (e.g. `~/.tmux/plugins/...`):
 
 ```json
 {
@@ -154,7 +176,8 @@ Set any of these before the plugin loads (defaults shown):
 set -g @claude_launch_key     'y'        # prefix key: launch/open for current dir
 set -g @claude_list_key       'u'        # prefix key: open the picker
 set -g @claude_command        'claude'   # command run in new sessions
-set -g @claude_session_prefix 'claude-'  # tmux session name prefix
+set -g @claude_discover       'session'  # 'session' | 'pane' — what the picker lists
+set -g @claude_session_prefix 'claude-'  # tmux session name prefix (session mode)
 set -g @claude_popup_width     '90%'     # popup width
 set -g @claude_popup_height    '90%'     # popup height
 ```
@@ -164,11 +187,12 @@ set -g @claude_popup_height    '90%'     # popup height
 - The **launcher** creates a detached `claude-<hash-of-dir>` tmux session running
   `claude`, records the window it came from in `@claude_origin`, and attaches to
   it in a popup.
-- The **hooks** set `@claude_state` / `@claude_state_at` on each session as Claude
-  works.
-- The **picker** lists sessions matching the prefix, reads their state and a live
-  `capture-pane` preview, and on selection moves your client to the session's
-  origin window before resuming it in the popup.
+- The **hooks** set `@claude_state` / `@claude_state_at` on each session — or each
+  pane, in `pane` mode — as Claude works.
+- The **picker** lists matching sessions (or, in `pane` mode, every pane running
+  `claude`), reads their state and a live `capture-pane` preview, and on selection
+  moves your client to the session's origin window before resuming it in the popup
+  — or, in `pane` mode, switches to the chosen pane.
 - Pressing `prefix` + `u` **from inside a session popup** detaches that popup
   first (closing it), then reopens the picker full-size on the outer host client —
   so you never end up with a cramped popup-in-popup.

--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# Open the session picker in a popup.
+# Open the session picker in a popup, on the client that invoked it.
+#
+# Arg: <invoking-client> — expanded from #{client_name} by the key binding. Used
+# to host the popup on the screen you actually pressed the key on, which matters
+# once several clients are attached. Falls back to a heuristic when absent.
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
@@ -9,38 +13,58 @@ prefix="$(get_tmux_option @claude_session_prefix 'claude-')"
 w="$(get_tmux_option @claude_popup_width '90%')"
 h="$(get_tmux_option @claude_popup_height '90%')"
 
-# The session of a client attached to a prefixed session — i.e. the popup we are
-# inside, if any. Empty when invoked from a normal (non-popup) pane.
+# session_of <client> — the session a client is attached to (empty if not live).
+session_of() {
+  tmux list-clients -F '#{client_name}	#{session_name}' 2>/dev/null |
+    awk -F'\t' -v c="$1" '$1 == c { print $2; exit }'
+}
+
+# nested_session — any client attached to a prefixed (popup) session. Used as a
+# fallback to detect "we're inside a session popup" when the invoker is unknown.
 nested_session() {
   tmux list-clients -F '#{client_name} #{session_name}' 2>/dev/null |
     awk -v p="$prefix" 'index($2, p) == 1 { print $2; exit }'
 }
 
-# A client NOT attached to a prefixed session — the outer client that should host
-# the picker popup.
+# host_client — first client NOT attached to a prefixed session: a safe outer
+# host for the popup (used for the nested case and as a last-resort fallback).
 host_client() {
   tmux list-clients -F '#{client_name} #{session_name}' 2>/dev/null |
     awk -v p="$prefix" 'index($2, p) != 1 { print $1; exit }'
 }
 
-# If we are inside a session popup, close it (detach its client)
-sess="$(nested_session)"
-if [ -n "$sess" ]; then
-  tmux detach-client -s "$sess"
-  # Wait until the session is gone
-  for _ in $(seq 1 100); do
-    [ -z "$(nested_session)" ] && break
-    sleep 0.05
-  done
+# Trust the invoking client only if it's still a live client.
+client="${1:-}"
+[ -n "$client" ] && [ -n "$(session_of "$client")" ] || client=''
+
+# Detect whether we were invoked from inside a session popup.
+nested=''
+if [ -n "$client" ]; then
+  csession="$(session_of "$client")"
+  [ "${csession#"$prefix"}" != "$csession" ] && nested="$csession"
+else
+  nested="$(nested_session)"
 fi
 
-host="$(host_client)"
-tmux set-option -g @claude_parent "$host"
-
-# Host the picker on the outer client. -c is honored because that client has no
-# popup open now; fall back to the default client if none was found.
-if [ -n "$host" ]; then
-  tmux display-popup -c "$host" -w "$w" -h "$h" -E "$DIR/picker.sh"
+if [ -n "$nested" ]; then
+  # Close the popup we're inside, then host the picker full-size on an outer
+  # client. -c is required here: the invoking client is gone after the detach.
+  tmux detach-client -s "$nested"
+  for _ in $(seq 1 100); do
+    tmux list-clients -F '#{session_name}' 2>/dev/null | grep -q "^${prefix}" || break
+    sleep 0.05
+  done
+  host="$(host_client)"
+  tmux set-option -g @claude_parent "$host"
+  if [ -n "$host" ]; then
+    tmux display-popup -c "$host" -w "$w" -h "$h" -E "$DIR/picker.sh"
+  else
+    tmux display-popup -w "$w" -h "$h" -E "$DIR/picker.sh"
+  fi
 else
+  # Normal invocation: open on the client that pressed the key. Omit -c so tmux
+  # hosts the popup on the invoking client (like the launcher) — correct even
+  # with several clients attached, where guessing a host picks the wrong screen.
+  tmux set-option -g @claude_parent "${client:-$(host_client)}"
   tmux display-popup -w "$w" -h "$h" -E "$DIR/picker.sh"
 fi

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -1,36 +1,70 @@
 #!/usr/bin/env bash
 # Interactive picker for running Claude sessions.
 #
-#   picker.sh           fzf picker; on enter, switches the parent client to the
-#                       chosen session's origin window and resumes it in the popup.
+#   picker.sh           fzf picker; on enter, jump to the chosen Claude.
 #   picker.sh --list    print the rows only (used by fzf's ctrl-x reload).
+#
+# @claude_discover (default 'session') chooses what is listed:
+#   session  tmux sessions named with @claude_session_prefix (the launcher model);
+#            state per-session; enter resumes the session in the popup.
+#   pane     every pane whose foreground command is @claude_command, however it was
+#            started (tmuxinator, a manual `claude`, …); state per-pane; enter
+#            switches to the pane's window and selects it.
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
 . "$DIR/helpers.sh"
 
+mode="$(get_tmux_option @claude_discover 'session')"
 prefix="$(get_tmux_option @claude_session_prefix 'claude-')"
+cmd="$(get_tmux_option @claude_command 'claude')"
 
+# set_icon <state> — sets $icon (coloured dot + label) and $rank (sort key).
+set_icon() {
+  case "$1" in
+  waiting) icon=$'\033[33m●\033[0m waiting' rank=0 ;; # yellow - needs input
+  idle) icon=$'\033[32m●\033[0m idle   ' rank=1 ;;    # green  - done, your turn
+  working) icon=$'\033[31m●\033[0m working' rank=3 ;; # red    - busy, leave it
+  *) icon=$'\033[90m●\033[0m   ?    ' rank=2 ;;       # grey   - unknown (no hook yet)
+  esac
+}
+
+# Both modes emit the same columns, so the fzf/jump/kill code below is shared:
+#   rank \t id \t dest \t icon \t age \t label
+#     id    ctrl-x + preview target  (session name | pane id)
+#     dest  enter target             (origin window | session:window)
+# rank/id/dest are hidden (--with-nth=4,5,6); id/dest drive the actions. Sort by
+# rank asc (attention-needed floats up) then age asc (just-finished on top); the
+# age field's leading number is read by -k5,5n ("5m" -> 5, "-" -> 0).
 emit_rows() {
-  local now s state at path icon rank ago
+  local now icon rank ago at pcmd id dest path title wname
   now=$(date +%s)
-  tmux list-sessions -F '#{session_name}' 2>/dev/null | grep "^${prefix}" | while IFS= read -r s; do
-    state=$(tmux show-options -qv -t "$s" @claude_state 2>/dev/null)
-    at=$(tmux show-options -qv -t "$s" @claude_state_at 2>/dev/null)
-    path=$(tmux display-message -p -t "$s" '#{pane_current_path}' 2>/dev/null)
-    case "$state" in
-    waiting) icon=$'\033[33m●\033[0m waiting' rank=0 ;; # yellow - needs input
-    idle) icon=$'\033[32m●\033[0m idle   ' rank=1 ;;    # green  - done, your turn
-    working) icon=$'\033[31m●\033[0m working' rank=3 ;; # red    - busy, leave it
-    *) icon=$'\033[90m●\033[0m   ?    ' rank=2 ;;       # grey   - unknown (no hook yet)
-    esac
-    if [ -n "$at" ]; then ago="$(((now - at) / 60))m"; else ago='-'; fi
-    # rank \t session \t icon \t age \t path   (rank/session hidden via --with-nth)
-    printf '%s\t%s\t%s\t%5s\t%s\n' "$rank" "$s" "$icon" "$ago" "${path/#$HOME/~}"
-    # rank asc (attention-needed floats up), then age asc so the session that
-    # finished just now sits at the top of its group. -k4,4n reads the leading
-    # number of the age field ("5m" -> 5; "-" -> 0).
-  done | sort -t$'\t' -k1,1n -k4,4n
+  if [ "$mode" = 'pane' ]; then
+    tmux list-panes -a -F \
+      '#{pane_current_command}	#{pane_id}	#{session_name}:#{window_index}	#{pane_current_path}	#{pane_title}	#{window_name}' \
+      2>/dev/null |
+      while IFS=$'\t' read -r pcmd id dest path title wname; do
+        [ "$pcmd" = "$cmd" ] || continue
+        set_icon "$(tmux show-options -pqv -t "$id" @claude_state 2>/dev/null)"
+        at=$(tmux show-options -pqv -t "$id" @claude_state_at 2>/dev/null)
+        if [ -n "$at" ]; then ago="$(((now - at) / 60))m"; else ago='-'; fi
+        # Prefer Claude's pane title (it sets a task summary); fall back to window
+        # name. Append the dir so same-titled panes stay distinguishable.
+        printf '%s\t%s\t%s\t%s\t%5s\t%b\n' "$rank" "$id" "$dest" "$icon" "$ago" \
+          "${title:-$wname}  \033[90m${path/#$HOME/~}\033[0m"
+      done
+  else
+    tmux list-sessions -F '#{session_name}' 2>/dev/null | grep "^${prefix}" |
+      while IFS= read -r id; do
+        set_icon "$(tmux show-options -qv -t "$id" @claude_state 2>/dev/null)"
+        at=$(tmux show-options -qv -t "$id" @claude_state_at 2>/dev/null)
+        dest=$(tmux show-options -qv -t "$id" @claude_origin 2>/dev/null)
+        path=$(tmux display-message -p -t "$id" '#{pane_current_path}' 2>/dev/null)
+        if [ -n "$at" ]; then ago="$(((now - at) / 60))m"; else ago='-'; fi
+        printf '%s\t%s\t%s\t%s\t%5s\t%s\n' "$rank" "$id" "$dest" "$icon" "$ago" \
+          "${path/#$HOME/~}"
+      done
+  fi | sort -t$'\t' -k1,1n -k5,5n
 }
 
 [ "${1:-}" = '--list' ] && {
@@ -43,22 +77,34 @@ if ! command -v fzf >/dev/null 2>&1; then
   exit 0
 fi
 
+# ctrl-x removes the highlighted entry: a pane in pane mode, a session otherwise.
+if [ "$mode" = 'pane' ]; then kill_cmd='kill-pane'; else kill_cmd='kill-session'; fi
+
 self="${BASH_SOURCE[0]}"
 export FZF_DEFAULT_OPTS=''
-sel=$(emit_rows | fzf --ansi --delimiter='\t' --with-nth=3,4,5 \
+sel=$(emit_rows | fzf --ansi --delimiter='\t' --with-nth=4,5,6 \
   --reverse --cycle --header='Claude sessions · enter: jump · ctrl-x: kill' \
   --preview="tmux capture-pane -ept {2}" --preview-window='right,62%,wrap' \
-  --bind="ctrl-x:execute-silent(tmux kill-session -t {2})+reload($self --list)")
+  --bind="ctrl-x:execute-silent(tmux $kill_cmd -t {2})+reload($self --list)")
 
 [ -z "$sel" ] && exit 0
-target=$(printf '%s' "$sel" | cut -f2)
-
-# Move the underlying parent client to the session's origin window (best-effort),
-# then resume the session in THIS popup over it. Falls back to resuming over the
-# current window when origin/parent are unknown.
-origin=$(tmux show-options -qv -t "$target" @claude_origin 2>/dev/null)
+id=$(printf '%s' "$sel" | cut -f2)
+dest=$(printf '%s' "$sel" | cut -f3)
 parent=$(tmux show-options -gqv @claude_parent 2>/dev/null)
-[ -n "$origin" ] && [ -n "$parent" ] &&
-  tmux switch-client -c "$parent" -t "$origin" 2>/dev/null
 
-tmux attach-session -t "$target"
+if [ "$mode" = 'pane' ]; then
+  # Move the host client to the pane's window, then select the pane. The popup
+  # closes as picker.sh exits, revealing the target underneath.
+  if [ -n "$parent" ]; then
+    tmux switch-client -c "$parent" -t "$dest" 2>/dev/null
+  else
+    tmux switch-client -t "$dest" 2>/dev/null
+  fi
+  tmux select-pane -t "$id" 2>/dev/null
+else
+  # Move the parent client to the session's origin window (best-effort), then
+  # resume the session in THIS popup over it.
+  [ -n "$dest" ] && [ -n "$parent" ] &&
+    tmux switch-client -c "$parent" -t "$dest" 2>/dev/null
+  tmux attach-session -t "$id"
+fi

--- a/scripts/state.sh
+++ b/scripts/state.sh
@@ -1,14 +1,29 @@
 #!/usr/bin/env bash
-# Record a Claude Code session's state on its tmux session, for the picker.
-# Wire this into Claude Code hooks (see README):  state.sh <working|waiting|idle>
+# Record a Claude Code session's state for the picker, via Claude Code hooks:
+#   state.sh <working|waiting|idle>
 #
 # Claude Code hooks inherit the Claude process environment, so $TMUX_PANE is set
 # whenever Claude runs inside tmux. Outside tmux this is a no-op.
+#
+# Where the state is stamped follows @claude_discover (see README):
+#   session  (default)  on the tmux session — the launcher model.
+#   pane                 on the tmux pane — so several Claudes sharing one session
+#                        (each in its own window or pane) report independently.
 [ -z "$TMUX_PANE" ] && exit 0
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers.sh
+. "$DIR/helpers.sh"
 
-session=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}' 2>/dev/null) || exit 0
-[ -z "$session" ] && exit 0
+now="$(date +%s)"
+state="${1:-idle}"
 
-tmux set-option -t "$session" @claude_state "${1:-idle}"
-tmux set-option -t "$session" @claude_state_at "$(date +%s)"
+if [ "$(get_tmux_option @claude_discover 'session')" = 'pane' ]; then
+  tmux set-option -p -t "$TMUX_PANE" @claude_state "$state" 2>/dev/null
+  tmux set-option -p -t "$TMUX_PANE" @claude_state_at "$now" 2>/dev/null
+else
+  session=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}' 2>/dev/null) || exit 0
+  [ -z "$session" ] && exit 0
+  tmux set-option -t "$session" @claude_state "$state"
+  tmux set-option -t "$session" @claude_state_at "$now"
+fi
 exit 0


### PR DESCRIPTION
## What this does

Introduces a new `@claude_discover` option that lets the picker find Claude sessions in two ways, plus a fix so the picker popup always opens on the client that invoked it.

### New: `@claude_discover` toggle

`@claude_discover` controls what the picker lists (default `session`, so existing behavior is unchanged):

- **`session`** (default) — list tmux sessions whose name starts with `@claude_session_prefix` (`claude-*`). This is the existing launcher model: one session per `prefix + y`, state stamped per session, and `enter` resumes the session in the popup.
- **`pane`** — list every tmux pane whose foreground command is `@claude_command` (`claude`), regardless of how it was started (this plugin, tmuxinator, or a manual `claude`). State is stamped per pane, so multiple Claudes in the same session report independently. `enter` switches to the pane's window and selects it; `ctrl-x` kills the pane.

Set pane discovery with:

```tmux
set -g @claude_discover 'pane'
```

### Fixed: picker popup opens on the invoking client

`list.sh` previously ignored the invoking client passed by the key binding and guessed a host with `host_client()`. With multiple clients attached, the picker could open on the wrong screen, making `prefix + u` appear to do nothing.

Now the popup opens on the client that pressed the key (omitting `-c`, matching the launcher behavior), and `-c` is only forced onto an outer client in the nested-popup case.

### Files changed

- `scripts/picker.sh` — supports both `session` and `pane` discovery modes via a shared row schema; updates preview, jump, and kill behavior accordingly.
- `scripts/state.sh` — stamps `@claude_state` / `@claude_state_at` on the session or the pane depending on `@claude_discover`.
- `scripts/list.sh` — uses the invoking client from the key binding and handles nested popups correctly.
- `README.md` — documents the new `@claude_discover` option and updates the architecture overview.
