### PR TITLE
Toggle the popup closed when the launch key is pressed inside it

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ run-shell ~/clone/path/claude_session_manager.tmux
 
 | Key            | Action                                                                          |
 | -------------- | ------------------------------------------------------------------------------- |
-| `prefix` + `y` | Launch (or re-attach to) a Claude session for the current directory, in a popup |
+| `prefix` + `y` | Toggle a Claude session popup for the current directory (launch/re-attach, or close if already open) |
 | `prefix` + `u` | Open the session picker                                                         |
 
 Inside the picker:
@@ -163,7 +163,9 @@ set -g @claude_popup_height    '90%'     # popup height
 
 - The **launcher** creates a detached `claude-<hash-of-dir>` tmux session running
   `claude`, records the window it came from in `@claude_origin`, and attaches to
-  it in a popup.
+  it in a popup. Pressing the launch key again **from inside that popup** detaches
+  it (closing the popup), so the same key toggles the popup open and shut while the
+  Claude session keeps running in the background.
 - The **hooks** set `@claude_state` / `@claude_state_at` on each session as Claude
   works.
 - The **picker** lists sessions matching the prefix, reads their state and a live

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Launch (or re-attach to) a Claude session for a directory, shown in a popup.
+# Pressing the launch key again from inside the popup toggles it closed.
 # Args: <dir> [origin-window-id]   (both expanded by run-shell in the binding)
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,8 +17,10 @@ h="$(get_tmux_option @claude_popup_height '90%')"
 
 session="${prefix}$(session_hash "$path")"
 
+# Already inside a session popup: toggle it closed. Detaching the popup client
+# dismisses the popup while leaving the Claude session running in the background.
 if [[ "$(tmux display-message -p '#S')" == "$prefix"* ]]; then
-  tmux display-message '🫪 Popup window already open'
+  tmux detach-client
   exit 0
 fi
 


### PR DESCRIPTION
## What

Pressing the launch key (`prefix` + `y`) again **from inside a session popup** now closes the popup, making the key a toggle.

## Why

Currently, when you're inside a Claude popup and press the launch key again, `launch.sh` just shows:

```
🫪 Popup window already open
```

That's a dead end — you have to reach for `prefix` + `d` (or some other detach) to dismiss it. Since the launch key is the one already in muscle memory for "show me Claude here", having it also dismiss the popup is the natural toggle people expect.

## How

In `scripts/launch.sh`, when the current session name already matches the popup prefix, run `tmux detach-client` instead of printing the message. Detaching the popup client dismisses the popup while leaving the `claude-<hash>` session running in the background, so pressing the key again re-attaches and resumes right where you left off.

This mirrors how the picker (`prefix` + `u`) already detaches the popup when invoked from inside one.

## Diff

- `scripts/launch.sh`: replace the "already open" message with `tmux detach-client`
- `README.md`: document the toggle behavior

No new options or dependencies; behavior change is limited to the previously-inert "already open" case.