### PR TITLE
Optionally bind the launch/picker keys without the prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Set any of these before the plugin loads (defaults shown):
 ```tmux
 set -g @claude_launch_key     'y'        # prefix key: launch/open for current dir
 set -g @claude_list_key       'u'        # prefix key: open the picker
+set -g @claude_launch_prefix  'on'       # 'off' = bind launch key without prefix (pair with a modifier, e.g. M-y)
+set -g @claude_list_prefix    'on'       # 'off' = bind picker key without prefix (pair with a modifier, e.g. M-u)
 set -g @claude_command        'claude'   # command run in new sessions
 set -g @claude_session_prefix 'claude-'  # tmux session name prefix
 set -g @claude_popup_width     '90%'     # popup width

--- a/claude_session_manager.tmux
+++ b/claude_session_manager.tmux
@@ -11,14 +11,32 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 launch_key="$(get_tmux_option @claude_launch_key 'y')"
 list_key="$(get_tmux_option @claude_list_key 'u')"
+# Per-key prefix toggle. 'on' (default) keeps the historical prefix+<key>
+# behaviour; 'off' installs a root-table binding (tmux bind-key -n) so the key
+# fires without the prefix. Pair 'off' with a modifier key such as 'M-y' — a
+# bare letter in the root table would hijack normal typing.
+launch_prefix="$(get_tmux_option @claude_launch_prefix 'on')"
+list_prefix="$(get_tmux_option @claude_list_prefix 'on')"
+
+# bind_claude <key> <use_prefix on|off> <tmux command...>
+# Wraps bind-key so a key can live in either the prefix table or the root
+# table (-n, no prefix) depending on the per-key option.
+bind_claude() {
+  key="$1"; use_prefix="$2"; shift 2
+  if [ "$use_prefix" = 'off' ]; then
+    tmux bind-key -n "$key" "$@"
+  else
+    tmux bind-key "$key" "$@"
+  fi
+}
 
 # Launch (or re-attach to) a Claude session for the current pane's directory.
 # #{pane_current_path} / #{window_id} are expanded by run-shell before the args
 # reach the script.
-tmux bind-key "$launch_key" \
+bind_claude "$launch_key" "$launch_prefix" \
   run-shell "$CURRENT_DIR/scripts/launch.sh '#{pane_current_path}' '#{window_id}'"
 
 # Open the session picker. When pressed from inside a session popup, list.sh
 # closes that popup first so the picker opens full-size on the outer client.
-tmux bind-key "$list_key" \
+bind_claude "$list_key" "$list_prefix" \
   run-shell "$CURRENT_DIR/scripts/list.sh '#{client_name}'"


### PR DESCRIPTION
## What

Adds two options — `@claude_launch_prefix` and `@claude_list_prefix` — that control whether the launch (`y`) and picker (`u`) keys are bound under the tmux prefix or in the root table.

- Default `'on'` keeps the current behaviour exactly: `prefix` + `y` / `prefix` + `u`.
- Set either to `'off'` to bind the key without the prefix (`tmux bind-key -n`), so it fires directly. Best paired with a modifier key, e.g. `@claude_launch_key 'M-y'` + `@claude_launch_prefix 'off'`.

## Why

Prefix-free, modifier-based bindings (`M-y` / `M-u`) are convenient for a launcher you hit constantly, and stay reachable even under an IME where typing the bare key is awkward.

## How

A small `bind_claude` wrapper chooses the prefix table or the root table (`-n`) per key based on the option; the bound `run-shell` commands are unchanged. Documented the two options in the README.