### PR TITLE
Add vim-style navigation keys option for picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,13 @@ set -g @claude_command        'claude'   # command run in new sessions
 set -g @claude_session_prefix 'claude-'  # tmux session name prefix
 set -g @claude_popup_width     '90%'     # popup width
 set -g @claude_popup_height    '90%'     # popup height
+set -g @claude_vim_keys        '0'       # '1' enables vim-style keys in the picker
 ```
+
+With `@claude_vim_keys '1'`, the picker starts in a navigation mode: `j`/`k` move
+down/up, `l` (or `enter`) jumps to the session, `h` closes the picker, and `i`
+starts fuzzy search. Press `esc` to leave search and return to navigation, or
+`esc` again to close the picker.
 
 ## How it works
 

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -10,6 +10,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$DIR/helpers.sh"
 
 prefix="$(get_tmux_option @claude_session_prefix 'claude-')"
+vim_keys="$(get_tmux_option @claude_vim_keys '0')"
 
 emit_rows() {
   local now s state at path icon rank ago
@@ -45,10 +46,26 @@ fi
 
 self="${BASH_SOURCE[0]}"
 export FZF_DEFAULT_OPTS=''
-sel=$(emit_rows | fzf --ansi --delimiter='\t' --with-nth=3,4,5 \
-  --reverse --cycle --header='Claude sessions · enter: jump · ctrl-x: kill' \
-  --preview="tmux capture-pane -ept {2}" --preview-window='right,62%,wrap' \
-  --bind="ctrl-x:execute-silent(tmux kill-session -t {2})+reload($self --list)")
+
+if [ "$vim_keys" = "1" ]; then
+  sel=$(emit_rows | fzf --ansi --delimiter=$'\t' --with-nth=3,4,5 \
+    --reverse --cycle --header='Claude sessions · enter/l: jump · ctrl-x: kill · j/k: nav · i: search · esc: back/close' \
+    --preview="tmux capture-pane -ept {2}" --preview-window='right,62%,wrap' \
+    --prompt='nav> ' \
+    --bind="ctrl-x:execute-silent(tmux kill-session -t {2})+reload($self --list)" \
+    --bind="start:disable-search" \
+    --bind="j:down" \
+    --bind="k:up" \
+    --bind="l:accept" \
+    --bind="h:abort" \
+    --bind="i:enable-search+change-prompt(search> )" \
+    --bind='esc:transform:[ "$FZF_PROMPT" = "search> " ] && echo "disable-search+change-prompt(nav> )" || echo "abort"')
+else
+  sel=$(emit_rows | fzf --ansi --delimiter=$'\t' --with-nth=3,4,5 \
+    --reverse --cycle --header='Claude sessions · enter: jump · ctrl-x: kill' \
+    --preview="tmux capture-pane -ept {2}" --preview-window='right,62%,wrap' \
+    --bind="ctrl-x:execute-silent(tmux kill-session -t {2})+reload($self --list)")
+fi
 
 [ -z "$sel" ] && exit 0
 target=$(printf '%s' "$sel" | cut -f2)


### PR DESCRIPTION
## What

Adds an opt-in `@claude_vim_keys` option (`'0'` by default) that switches the
session picker into a modal, vim-style keymap:

- `j` / `k` — move down / up
- `l` or `enter` — jump to the selected session
- `h` — close the picker
- `i` — start fuzzy search
- `esc` — leave search and return to navigation; press `esc` again in nav mode
  to close the picker

When the option is unset (the default), the picker behaves exactly as before.

## Why

Lets vim users navigate the picker from the home row without reaching for arrow
keys, without changing the default experience for anyone else.

## Notes

- The mode is tracked via fzf's prompt (`nav> ` / `search> `); the `esc` binding
  uses a `transform` action to decide between returning to nav mode and aborting.
- The new option is documented in the README options table.