### PR TITLE
fix(list): Detect popup clients by process ancestry, not session name

### DIFF
--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -18,8 +18,30 @@ me="${1:-}"
 my_session="$(tmux list-clients -F '#{client_name} #{session_name}' 2>/dev/null |
   awk -v me="$me" '$1 == me { print $2; exit }')"
 
+# A popup client is spawned by the tmux server itself, so its process ancestry
+# reaches the server pid. A regular client (attached from a terminal) descends
+# from the user's shell instead. Session name alone can't tell them apart: a
+# claude-* session can also be entered by a plain attach (e.g. choose-tree),
+# and detaching that client would kick the user out entirely.
+is_popup_client() {
+  local pid server_pid
+  pid="$(tmux list-clients -F '#{client_name} #{client_pid}' 2>/dev/null |
+    awk -v me="$1" '$1 == me { print $2; exit }')"
+  server_pid="$(tmux display-message -p '#{pid}')"
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ] 2>/dev/null; do
+    pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')"
+    [ "$pid" = "$server_pid" ] && return 0
+  done
+  return 1
+}
+
+in_popup=no
 case "$my_session" in
-"$prefix"*)
+"$prefix"*) is_popup_client "$me" && in_popup=yes ;;
+esac
+
+case "$in_popup" in
+yes)
   # We are inside a session popup: close it, then reopen the picker on the
   # outer client that originally opened it.
   tmux detach-client -s "$my_session"


### PR DESCRIPTION
## Problem

`list.sh` decides "we are inside a session popup" by checking whether the invoking client's session name starts with the `claude-` prefix. But a `claude-*` session can also be entered through a plain attach — e.g. picking it from `choose-tree` (`prefix` + `w`/`s`) or `tmux attach -t claude-xxxx`.

In that case, pressing `prefix` + `u` hits the popup branch and runs `detach-client -s` on the session, which kicks the user out of tmux entirely instead of opening the picker. The picker is then reopened on `@claude_parent`, which at that point is stale or empty.

**Steps to reproduce:**
1. `prefix` + `y` — launch a Claude session, then detach from the popup
2. `prefix` + `w` — select the `claude-*` session and attach to it directly
3. `prefix` + `u` — expected: the picker opens; actual: the client is detached and you land back in your shell

## Fix

Detect an actual popup instead of inferring it from the session name. A popup client is spawned by the tmux server itself (`display-popup -E "tmux attach-session ..."`), so its process ancestry reaches the server pid. A regular client attached from a terminal descends from the user's shell. `is_popup_client` walks the client pid's parent chain and only takes the detach path when it reaches the server pid.

The session-name check is kept as a cheap precondition — only `claude-*` sessions are ever hosted in the plugin's popups — and the ancestry walk confirms the client really is one.

## Testing

Verified on macOS (tmux 3.7b):
- popup client (opened via `display-popup -E 'tmux attach-session ...'`) → detected as popup, original detach-and-reopen behavior preserved
- the same `claude-*` session entered via plain `tmux attach` → detected as a regular client, picker opens in place without detaching