### PR TITLE
Fix command injection: shell-quote path/window/client in key bindings…

### DIFF
--- a/claude_session_manager.tmux
+++ b/claude_session_manager.tmux
@@ -16,9 +16,9 @@ list_key="$(get_tmux_option @claude_list_key 'u')"
 # #{pane_current_path} / #{window_id} are expanded by run-shell before the args
 # reach the script.
 tmux bind-key "$launch_key" \
-  run-shell "$CURRENT_DIR/scripts/launch.sh '#{pane_current_path}' '#{window_id}'"
+  run-shell "$CURRENT_DIR/scripts/launch.sh '#{q:pane_current_path}' '#{q:window_id}'"
 
 # Open the session picker. When pressed from inside a session popup, list.sh
 # closes that popup first so the picker opens full-size on the outer client.
 tmux bind-key "$list_key" \
-  run-shell "$CURRENT_DIR/scripts/list.sh '#{client_name}'"
+  run-shell "$CURRENT_DIR/scripts/list.sh '#{q:client_name}'"


### PR DESCRIPTION
## What

The `prefix + y` (launch) and `prefix + u` (picker) bindings interpolate tmux
format values into a `run-shell` command string wrapped in hand-written single
quotes. tmux expands formats **literally** (no shell-escaping), so a directory
whose name contains a single quote plus shell metacharacters breaks out of the
quoting and runs arbitrary commands as the user when they press the launch key
inside it.

This PR replaces the manual quoting with tmux's `#{q:…}` modifier, which
shell-quotes each value.

```diff
 tmux bind-key "$launch_key" \
-  run-shell "$CURRENT_DIR/scripts/launch.sh '#{pane_current_path}' '#{window_id}'"
+  run-shell "$CURRENT_DIR/scripts/launch.sh #{q:pane_current_path} #{q:window_id}"

 tmux bind-key "$list_key" \
-  run-shell "$CURRENT_DIR/scripts/list.sh '#{client_name}'"
+  run-shell "$CURRENT_DIR/scripts/list.sh #{q:client_name}"
```

`#{pane_current_path}` is the real vector (attacker-influenceable directory
name); `#{window_id}` / `#{client_name}` are tmux-internal but quoted too for
consistency.

## Reproduce the bug (before this change)

```sh
mkdir -p "/tmp/poc/p'\$(touch \$HOME/PWNED)'q"
cd "/tmp/poc/p'\$(touch \$HOME/PWNED)'q"
# press  prefix + y  →  ~/PWNED is created; the $(...) ran with no confirmation
```

Minimal proof tmux does not escape the expanded value (tmux 3.6):

```sh
tmux set-option -g @evil "x'; touch /tmp/INJECTED ; echo '"
tmux run-shell "printf '%s' '#{@evil}'"   # -> /tmp/INJECTED is created
```

## Verification (after this change)

Same repro no longer fires: the path reaches the script as a single intact
argument and no command substitution runs. `#{q:…}` is available in the
tmux ≥ 3.2 the plugin already requires, so there is no new dependency.

## Impact

Arbitrary command execution as the invoking user (no privilege escalation).
Low likelihood — needs the victim to `cd` into a crafted-name directory (e.g.
from a cloned repo/archive) and press the launch key — but it is real code
execution, not display corruption.