### PR TITLE
fix(launch): quote the session name in display-popup, guard a missing cwd

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -27,7 +27,8 @@ session_hash() {
   else
     out="$(printf '%s\n' "$1" | shasum)"
   fi
-  printf '%s' "${out%% *}" | cut -c1-8
+  out="${out%% *}"
+  printf '%s' "${out:0:8}"
 }
 
 # file_mtime <path>

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -29,4 +29,7 @@ tmux has-session -t "$session" 2>/dev/null ||
 # Record which window launched it, so the picker can jump back here later.
 [ -n "$window" ] && tmux set-option -t "$session" @claude_origin "$window"
 
-tmux display-popup -w "$w" -h "$h" -E "tmux attach-session -t $session"
+# -E takes a command string that a second shell re-parses, so the session name is
+# quoted for that shell too — @claude_session_prefix is user-set and may contain
+# spaces or shell metacharacters.
+tmux display-popup -w "$w" -h "$h" -E "tmux attach-session -t '$session'"

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -24,8 +24,6 @@ if [[ "$(tmux display-message -p '#S')" == "$prefix"* ]]; then
 fi
 
 if ! tmux has-session -t "$session" 2>/dev/null; then
-  # Only guard the create path: an existing session stays attachable even if the
-  # directory it was launched from has since been renamed or removed.
   [ -d "$path" ] || {
     tmux display-message "tmux-claude-session-manager: $path no longer exists"
     exit 0
@@ -36,7 +34,4 @@ fi
 # Record which window launched it, so the picker can jump back here later.
 [ -n "$window" ] && tmux set-option -t "$session" @claude_origin "$window"
 
-# -E takes a command string that a second shell re-parses, so the session name is
-# quoted for that shell too — @claude_session_prefix is user-set and may contain
-# spaces or shell metacharacters.
 tmux display-popup -w "$w" -h "$h" -E "tmux attach-session -t '$session'"

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -23,8 +23,15 @@ if [[ "$(tmux display-message -p '#S')" == "$prefix"* ]]; then
   exit 0
 fi
 
-tmux has-session -t "$session" 2>/dev/null ||
+if ! tmux has-session -t "$session" 2>/dev/null; then
+  # Only guard the create path: an existing session stays attachable even if the
+  # directory it was launched from has since been renamed or removed.
+  [ -d "$path" ] || {
+    tmux display-message "tmux-claude-session-manager: $path no longer exists"
+    exit 0
+  }
   tmux new-session -d -s "$session" -c "$path" "$cmd"
+fi
 
 # Record which window launched it, so the picker can jump back here later.
 [ -n "$window" ] && tmux set-option -t "$session" @claude_origin "$window"


### PR DESCRIPTION
Three small, independent changes to `scripts/launch.sh` and `scripts/helpers.sh`. Each is its own commit, so please feel free to take some and drop others.

### 1. Shell-quote the session name passed to `display-popup -E`

`display-popup -E` takes a *command string* that a second shell re-parses, so the outer bash quoting is already gone by the time the session name is used:

```bash
-E "tmux attach-session -t $session"
```

`$session` is `${prefix}$(session_hash "$path")`, and `@claude_session_prefix` is a documented user option (README:93). With the default `claude-` the remainder is hex, so this is latent rather than exploitable — but a prefix containing a space splits the `-t` target, and one containing `;` ends the command early.

Reproduces on current main:

```console
$ tmux new-session -d -s "my claude 12345678"
$ sh -c "tmux has-session -t my claude 12345678"
command has-session: too many arguments (need at most 0)
```

This looked like the one expansion left over after 6e65e9c hardened the key bindings with `#{q:…}`. `picker.sh` already does the equivalent correctly (`-t "$session"`), because there it's a plain argv element with no shell round-trip.

### 2. Report a missing directory instead of an empty popup

`new-session -c "$path"` fails when the pane's directory has been renamed or deleted. Nothing checked the result — the scripts run under `set -uo pipefail`, without `-e` — so the popup opened onto a session that was never created, then closed again with no explanation.

The guard sits inside the create branch only: an existing session stays attachable even when the directory it was launched from is gone, which is a real case since Claude keeps running in a deleted cwd.

I also converted the `||` to `if ! …; then` while touching it, since nesting a `||` block inside another one is hard to read. Happy to revert that part if you prefer the original shape.

### 3. Drop a subprocess from `session_hash`

`printf … | cut -c1-8` becomes bash parameter expansion. Small, but it runs once per session every time the picker opens.

**This is the commit worth scrutinising, since it touches a hash function.** Output is byte-identical. I kept `${out%% *}` as its own line rather than collapsing to `${out:0:8}` — both give the same answer, but only because all three hash tools happen to print the hash first, and I didn't want the code to depend on that silently.

## Testing

- `bash -n` clean across all scripts.
- `session_hash` compared old vs new implementation over paths with spaces, without spaces, and the empty string — identical output, so no existing session gets orphaned.
- The quoting fix verified against a real tmux server on a throwaway socket (transcript above).
- All three exercised live via a symlinked plugin directory: existing sessions still re-attach rather than duplicating, a nonexistent path now reports the error, and a prefix containing a space works.

No behaviour changes for anyone on default settings.
