### PR TITLE
Add instruction to README to close popup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ run-shell ~/clone/path/claude_session_manager.tmux
 | Key            | Action                                                                          |
 | -------------- | ------------------------------------------------------------------------------- |
 | `prefix` + `y` | Launch (or re-attach to) a Claude session for the current directory, in a popup |
+| `prefix` + `d` | Close the popup and go back to your window, Claude session keeps running        |
 | `prefix` + `u` | Open the agent picker                                                           |
 
 Inside the picker:


### PR DESCRIPTION
prefix + d is the standard tmux detach shortcut, it closes the popup and goes back to main window, keeping the claude session running in the background.

Note: Maybe is not necessary and only I didn't knew about it, but I got stuck on it like the first time I tried to quit nvim :)