### PR TITLE
Title, group, and surface what needs you in the picker

### DIFF
--- a/scripts/agents.sh
+++ b/scripts/agents.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Emit one picker row per running Claude that lives in a tmux pane.
+# Emit the picker rows: one per running Claude that lives in a tmux pane, plus
+# aggregate rows for things that exist but cannot be jumped to.
 #
 # Claude self-reports its status: each session writes its own state to disk and a
 # supervisor daemon aggregates it, which `claude agents --json` publishes. So this
@@ -10,54 +11,70 @@
 # is what lets several Claudes in one project (same cwd, same session, different
 # windows) each get a row of their own.
 #
-#   Row: rank \t pane_id \t pid \t kind \t icon \t age \t loc \t path
-#   rank/pane_id/pid/kind are hidden from the display via fzf's --with-nth.
+#   Row: grp \t proj \t rank \t agemin \t pane_id \t pid \t kind \t display
+#         \___________ sort + dispatch keys, hidden ___________/ \_ --with-nth=8 _/
+#
+# The visible half is one pre-padded field rather than several, because fzf joins
+# --with-nth fields back together with the delimiter — a tab here — and tab stops
+# would jitter the columns out of alignment as titles change length.
+#
+# Rows cluster by project, and a project is ordered by its most urgent member, so
+# grouping never buries something that needs you. `kind` tells picker.sh how to
+# act on a row: loose/dedicated jump to a pane, bg opens the background-agent
+# view, note is inert.
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
 . "$DIR/helpers.sh"
 
 agents="$(claude agents --json 2>/dev/null)" || exit 0
+[ -n "$agents" ] || exit 0
+
 rows="$(printf '%s' "$agents" |
-  jq -r '.[] | select(.kind == "interactive") | [.pid, .status, .sessionId, .cwd] | @tsv' 2>/dev/null)"
-[ -n "$rows" ] || exit 0
+  jq -r '.[] | select(.kind == "interactive")
+        | [.pid, .status, .sessionId, .cwd, (.waitingFor // "")] | @tsv' 2>/dev/null)"
 
-# Resolved out here because only `stat`, outside awk, can read an mtime.
-mtimes="$(printf '%s\n' "$rows" | cut -f3 | while IFS= read -r sid; do
-  printf 'M\t%s\t%s\n' "$sid" "$(claude_transcript_mtime "$sid")"
-done)"
+# Background agents carry `id` and `state`, never `pid`/`status` like interactive
+# ones — different keys, and non-overlapping vocabularies (working/blocked/done/
+# failed/stopped vs idle/busy/waiting). With no pid there is no tty and no pane,
+# so they can never be rows
+# you jump to; they collapse into one row that opens `claude agents` instead.
+#
+# Counted off the same JSON. Without --all it already omits completed sessions, so
+# what is left is live. The documented states are working|blocked|done|failed|
+# stopped; `blocked` and `failed` are the two that want a human, and anything else
+# still listed is running. Split by naming the attention states rather than the
+# running ones, so a state added later shows up as running instead of silently
+# inflating the count that pins this row to the top.
+bg_attn="$(printf '%s' "$agents" |
+  jq '[.[] | select(.kind == "background" and (.state == "blocked" or .state == "failed"))] | length' 2>/dev/null)"
+bg_active="$(printf '%s' "$agents" |
+  jq '[.[] | select(.kind == "background" and .state != "blocked" and .state != "failed")] | length' 2>/dev/null)"
 
-# Three tagged streams into one awk: pid->tty, tty->pane, session->last-activity.
-# Total cost is 3 subprocesses regardless of how many sessions or panes exist.
+# Resolved out here because awk can read neither an mtime nor a second file.
+# One glob per session feeds both columns.
+meta=''
+if [ -n "$rows" ]; then
+  meta="$(printf '%s\n' "$rows" | cut -f3 | while IFS= read -r sid; do
+    [ -n "$sid" ] || continue
+    f="$(claude_transcript_path "$sid")"
+    printf 'M\t%s\t%s\t%s\n' \
+      "$sid" "$(claude_transcript_mtime "$f")" "$(claude_transcript_title "$f")"
+  done)"
+fi
+
+# Four tagged streams into one awk: pid->tty, tty->pane, session->activity+title,
+# and the agents themselves. Total cost is 3 subprocesses regardless of how many
+# sessions or panes exist.
 {
   ps -Ao pid=,tty= 2>/dev/null | awk '{ print "P\t" $1 "\t" $2 }'
   tmux list-panes -a -F $'T\t#{pane_tty}\t#{pane_id}\t#{session_name}\t#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null
-  printf '%s\n' "$mtimes"
-  printf '%s\n' "$rows" | sed $'s/^/A\t/'
-} | awk -F'\t' -v now="$(date +%s)" -v home="$HOME" \
-  -v prefix="$(get_tmux_option @claude_session_prefix 'claude-')" '
-  $1 == "P" { tty_of[$2] = $3; next }
-  $1 == "T" { sub(/^\/dev\//, "", $2); pane[$2] = $3; sess[$2] = $4; loc[$2] = $5; next }
-  $1 == "M" { seen_at[$2] = $3; next }
-  $1 == "A" {
-    tty = tty_of[$2]
-    if (tty == "" || !(tty in pane)) next   # this Claude is not running inside tmux
-
-    if      ($3 == "waiting") { icon = "\033[33m●\033[0m waiting"; rank = 0 }  # yellow - needs input
-    else if ($3 == "idle")    { icon = "\033[32m●\033[0m idle   "; rank = 1 }  # green  - done, your turn
-    else if ($3 == "busy")    { icon = "\033[31m●\033[0m working"; rank = 3 }  # red    - busy, leave it
-    else                      { icon = "\033[90m●\033[0m   ?    "; rank = 2 }  # grey   - unrecognised status
-
-    age = (seen_at[$4] != "") ? int((now - seen_at[$4]) / 60) "m" : "-"
-    kind = (index(sess[tty], prefix) == 1) ? "dedicated" : "loose"
-
-    path = $5
-    if (index(path, home) == 1) path = "~" substr(path, length(home) + 1)
-
-    printf "%s\t%s\t%s\t%s\t%s\t%5s\t%s\t%s\n",
-      rank, pane[tty], $2, kind, icon, age, loc[tty], path
-  }
-' | sort -t$'\t' -k1,1n -k6,6n
-# rank asc (what needs you floats up), then age asc so whatever just went idle
-# sits at the top of its group. -k6,6n reads the leading number of the age field
-# ("5m" -> 5; "-" -> 0).
+  [ -n "$meta" ] && printf '%s\n' "$meta"
+  [ -n "$rows" ] && printf '%s\n' "$rows" | sed $'s/^/A\t/'
+} | awk -F'\t' -v now="$(date +%s)" \
+  -v bg_attn="${bg_attn:-0}" -v bg_active="${bg_active:-0}" \
+  -v projw="$(get_tmux_option @claude_project_width '24')" \
+  -v prefix="$(get_tmux_option @claude_session_prefix 'claude-')" \
+  -f "$DIR/rows.awk" | sort -t$'\t' -k1,1n -k2,2 -k3,3n -k4,4n
+# Group by most-urgent-member first, then project name to keep a group contiguous,
+# then rank and age within the group.

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -38,21 +38,56 @@ file_mtime() {
   stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null
 }
 
-# claude_transcript_mtime <session-id>
-# Epoch seconds of the last write to that Claude session's transcript — i.e. when
-# the agent last did anything. `claude agents --json` reports only `startedAt`,
-# never a last-activity time, so the transcript's mtime stands in for it.
+# reverse_lines <path>
+# Stream a file last line first. GNU coreutils ships `tac`, BSD/macOS ships
+# `tail -r`; neither exists on the other, so the fallback is unambiguous.
+reverse_lines() {
+  tac "$1" 2>/dev/null || tail -r "$1" 2>/dev/null
+}
+
+# claude_transcript_path <session-id>
+# Path to that session's transcript, or empty when it cannot be found.
 #
 # Found by glob so we never have to reproduce Claude's cwd -> project-slug
-# encoding. The path is an internal Claude Code detail and may move; an empty
-# result just renders the age column as '-'.
-claude_transcript_mtime() {
+# encoding. The layout is an internal Claude Code detail and may move; every
+# caller degrades to a blank column rather than failing.
+claude_transcript_path() {
   local base f
   base="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
   for f in "$base"/projects/*/"$1".jsonl; do
     [ -f "$f" ] && {
-      file_mtime "$f"
+      printf '%s' "$f"
       return
     }
   done
+}
+
+# claude_transcript_mtime <transcript-path>
+# Epoch seconds of the last write to a session's transcript — i.e. when the agent
+# last did anything. `claude agents --json` reports only `startedAt`, never a
+# last-activity time, so the transcript's mtime stands in for it.
+claude_transcript_mtime() {
+  [ -n "$1" ] && file_mtime "$1"
+}
+
+# claude_transcript_title <transcript-path>
+# The session's current AI-generated title. Claude Code appends an `ai-title`
+# record whenever its sense of the conversation's topic changes, so the last one
+# wins — hence reading the file backwards and stopping at the first hit.
+#
+# Parsed with jq rather than a regex because a title may legitimately contain a
+# quote, which a "[^"]*" match would truncate mid-word. Tabs and newlines are
+# squeezed out because these rows are TSV.
+#
+# The match is anchored: every transcript record is one JSON object per line, and
+# an unanchored search would also hit message records that merely quote the string
+# — a session whose own transcript discusses ai-title would shadow its real title
+# with a record that has no .aiTitle, blanking the column.
+claude_transcript_title() {
+  [ -n "$1" ] || return
+  reverse_lines "$1" |
+    grep -m1 '^{"type":"ai-title"' |
+    jq -r '.aiTitle // empty' 2>/dev/null |
+    tr '\t\n' '  ' |
+    sed 's/[[:space:]]*$//'
 }

--- a/scripts/kill.sh
+++ b/scripts/kill.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Kill the Claude behind a picker row, if it has one.
+# Args: <kind> <pid>
+#
+# The aggregate rows have no single process to kill. fzf's execute-silent throws
+# output away, so an unguarded `kill` here would fail invisibly and read as the
+# keybinding being broken; say what happened instead.
+set -uo pipefail
+
+kind="${1:-}"
+pid="${2:-}"
+
+case "$kind" in
+bg)
+  tmux display-message 'Kill background agents from the `claude agents` view (enter)'
+  ;;
+note)
+  tmux display-message 'That session is outside tmux — kill it where it runs'
+  ;;
+*)
+  if [ -n "$pid" ] && [ "$pid" != '-' ]; then
+    kill "$pid" 2>/dev/null || tmux display-message "Could not kill pid $pid"
+  fi
+  ;;
+esac

--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -5,10 +5,13 @@
 #   picker.sh --list    print the rows only (used by fzf's ctrl-x reload).
 #
 # Rows come from agents.sh, which pairs each running Claude with the tmux pane it
-# occupies. Two kinds of row jump differently:
+# occupies. Four kinds of row, dispatched on field 7:
 #   dedicated  a Claude in a `claude-*` session this plugin launched — resumed in
 #              the popup, over the window it was launched from.
 #   loose      a Claude running in any other pane — focused in place.
+#   bg         the aggregate background-agent row — replaces this picker with the
+#              `claude agents` view, in the same popup.
+#   note       informational only; selecting it does nothing.
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
@@ -35,15 +38,37 @@ fzf_options="$(get_tmux_option @claude_fzf_options '')"
 # ctrl-x kills the Claude process itself: a dedicated session dies with its last
 # window, while a loose pane keeps the shell that hosted it. The reload waits a
 # beat so the supervisor has dropped the agent from `claude agents --json`.
-sel=$("$DIR/agents.sh" | fzf --ansi --delimiter='\t' --with-nth=5,6,7,8 \
-  --reverse --cycle --header='Claude agents · enter: jump · ctrl-x: kill' \
-  --preview='tmux capture-pane -ept {2}' --preview-window='up,70%,follow' \
-  --bind="ctrl-x:execute-silent(kill {3})+reload(sleep 0.3; $self --list)" \
+#
+# ctrl-g is a shortcut to the same place enter takes you on the background row —
+# worth its own key because that row moves: it pins to the top only while an agent
+# is blocked, and sits at the bottom the rest of the time.
+#
+# ctrl-g comes back through --expect rather than a become()/execute() binding:
+# fzf's stdout is this command substitution, so anything launched from inside the
+# binding would render into $out instead of onto the popup. Letting fzf exit first
+# puts the terminal back in this script's hands.
+out=$("$DIR/agents.sh" | fzf --ansi --delimiter='\t' --with-nth=8 \
+  --reverse --cycle --expect=ctrl-g \
+  --header='Claude agents · enter: jump · ctrl-g: background agents · ctrl-x: kill' \
+  --preview="$DIR/preview.sh {7} {5} {6}" --preview-window='up,70%,follow' \
+  --bind="ctrl-x:execute-silent($DIR/kill.sh {7} {6})+reload(sleep 0.3; $self --list)" \
   ${extra_opts[@]+"${extra_opts[@]}"})
 
+# --expect puts the pressed key on line 1 (empty for a plain enter) and the chosen
+# row on line 2.
+key=$(printf '%s\n' "$out" | sed -n 1p)
+sel=$(printf '%s\n' "$out" | sed -n 2p)
+
+# Replaces the picker inside the popup it already owns, so there is no second
+# display-popup racing the first one's teardown (the dance list.sh has to do).
+[ "$key" = 'ctrl-g' ] && exec claude agents
+
 [ -z "$sel" ] && exit 0
-pane=$(printf '%s' "$sel" | cut -f2)
-kind=$(printf '%s' "$sel" | cut -f4)
+pane=$(printf '%s' "$sel" | cut -f5)
+kind=$(printf '%s' "$sel" | cut -f7)
+
+[ "$kind" = bg ] && exec claude agents
+[ "$kind" = note ] && exit 0
 
 parent=$(tmux show-options -gqv @claude_parent 2>/dev/null)
 session=$(tmux display-message -p -t "$pane" '#{session_name}' 2>/dev/null)

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Render the fzf preview for one picker row.
+# Args: <kind> <pane-id> <pid(s)>
+#
+# Only pane-backed rows have a pane to capture; the aggregate rows describe
+# themselves instead. Without this dispatch a `capture-pane` aimed at the
+# background row's placeholder id would fail into a blank box that looks like a
+# rendering bug.
+set -uo pipefail
+
+kind="${1:-}"
+pane="${2:-}"
+pids="${3:-}"
+
+case "$kind" in
+bg)
+  printf '\033[1mBackground agents\033[0m — enter opens the `claude agents` view.\n\n'
+  claude agents --json 2>/dev/null |
+    jq -r '
+      [.[] | select(.kind == "background")] as $bg
+      | if ($bg | length) == 0 then
+          "No live background agents."
+        else
+          ($bg | sort_by(.state != "blocked", .startedAt)
+               | map("  \(if .state == "blocked" then "●" else "·" end) \(.state | .[0:8] | . + (" " * (8 - length))) \(.name // .id)")
+               | join("\n"))
+        end'
+  ;;
+note)
+  printf '\033[1mRunning outside tmux\033[0m — no pane to jump to.\n\n'
+  printf 'Reachable only where they were started (a plain shell, another\n'
+  printf 'multiplexer, or a detached login). Listed here so the overview\n'
+  printf 'never hides a live session.\n\n'
+  [ -n "$pids" ] && [ "$pids" != '-' ] && ps -o pid=,lstart=,args= -p "$pids" 2>/dev/null
+  ;;
+*)
+  tmux capture-pane -ept "$pane" 2>/dev/null
+  ;;
+esac

--- a/scripts/rows.awk
+++ b/scripts/rows.awk
@@ -1,0 +1,101 @@
+# Build the picker rows from four tagged streams on stdin.
+#
+#   P  <pid> <tty>                       every process, from ps
+#   T  <tty> <pane_id> <session> <loc>   every tmux pane
+#   M  <sessionId> <mtime> <title>       per-session transcript facts
+#   A  <pid> <status> <sessionId> <cwd> <waitingFor>   the agents themselves
+#
+# Kept in its own file rather than quoted inline in agents.sh so it can be driven
+# from fixtures without a live tmux or a running Claude. See test/contract.sh.
+#
+# Required -v args: now bg_attn bg_active projw prefix
+  function dim(s) { return "\033[90m" s "\033[0m" }
+
+  # Sessions stay open for days, so raw minutes overflow the column and stop being
+  # readable at a glance ("7342m"). One unit, no decimals — this is a recency cue,
+  # not a measurement.
+  function fmt_age(mins) {
+    if (mins <   60) return mins "m"
+    if (mins < 2880) return int(mins / 60) "h"
+    return int(mins / 1440) "d"
+  }
+
+  # show <icon> <age> <loc> <project> <title>  — the whole visible row, padded here
+  # so alignment survives fzf reassembling it.
+  function show(icon, age, loc, project, title) {
+    return sprintf("%s %5s  %-9s  %s  %s", icon, age, loc,
+      dim(sprintf("%-" projw "." projw "s", project)), title)
+  }
+
+  $1 == "P" { tty_of[$2] = $3; next }
+  $1 == "T" { sub(/^\/dev\//, "", $2); pane[$2] = $3; sess[$2] = $4; loc[$2] = $5; next }
+  $1 == "M" { seen_at[$2] = $3; title[$2] = $4; next }
+  $1 == "A" {
+    tty = tty_of[$2]
+    # A Claude outside tmux has no pane to jump to. Counted, not dropped — an
+    # overview that quietly omits a running session is the bug this tool exists
+    # to fix.
+    if (tty == "" || !(tty in pane)) {
+      orphans++
+      orphan_pids = (orphan_pids == "") ? $2 : orphan_pids "," $2
+      next
+    }
+
+    if      ($3 == "waiting") { icon = "\033[33m●\033[0m waiting"; rank = 0 }  # yellow - needs input
+    else if ($3 == "idle")    { icon = "\033[32m●\033[0m idle   "; rank = 1 }  # green  - done, your turn
+    else if ($3 == "busy")    { icon = "\033[31m●\033[0m working"; rank = 3 }  # red    - busy, leave it
+    else                      { icon = "\033[90m●\033[0m   ?    "; rank = 2 }  # grey   - unrecognised status
+
+    agemin = (seen_at[$4] != "") ? int((now - seen_at[$4]) / 60) : 0
+    age    = (seen_at[$4] != "") ? fmt_age(agemin) : "-"
+
+    # Claude Code puts worktrees at <repo>/.claude/worktrees/<name>, so they fold
+    # into their repo group rather than each becoming a project of one, with the
+    # worktree name kept visible to tell sibling checkouts apart.
+    cwd = $5; wt = ""
+    if (match(cwd, /\/\.claude\/worktrees\//)) {
+      wt  = substr(cwd, RSTART + RLENGTH)
+      cwd = substr(cwd, 1, RSTART - 1)
+    }
+    proj = cwd; sub(/.*\//, "", proj)
+    cell = (wt != "") ? proj "/" wt : proj
+
+    n++
+    f_rank[n] = rank; f_agemin[n] = agemin; f_pane[n] = pane[tty]; f_pid[n] = $2
+    f_kind[n] = (index(sess[tty], prefix) == 1) ? "dedicated" : "loose"
+    f_icon[n] = icon; f_age[n] = age; f_loc[n] = loc[tty]
+    # `waitingFor` says what it is blocked on (permission prompt, input needed,
+    # sandbox request, ...) — the thing you actually triage on, so it leads.
+    f_cell[n] = cell; f_proj[n] = cwd
+    f_title[n] = ($3 == "waiting" && $6 != "") ? "\033[33m" $6 "\033[0m — " title[$4] : title[$4]
+
+    if (!(cwd in grp) || rank < grp[cwd]) grp[cwd] = rank
+  }
+
+  END {
+    for (i = 1; i <= n; i++)
+      printf "%d\t%s\t%d\t%d\t%s\t%s\t%s\t%s\n",
+        grp[f_proj[i]], f_proj[i], f_rank[i], f_agemin[i],
+        f_pane[i], f_pid[i], f_kind[i],
+        show(f_icon[i], f_age[i], f_loc[i], f_cell[i], f_title[i])
+
+    # Background agents: pinned above everything when any is blocked, parked at
+    # the bottom otherwise, so the row is a signal and not just a door.
+    if (bg_attn > 0) {
+      bg_icon = "\033[33m●\033[0m blocked"; bg_grp = -1
+      bg_text = bg_attn " need you" (bg_active > 0 ? ", " bg_active " running" : "")
+    } else {
+      bg_icon = "\033[90m●\033[0m agents "; bg_grp = 99
+      bg_text = (bg_active > 0 ? bg_active " running" : "none needing you")
+    }
+    printf "%d\t~background\t0\t0\t-\t-\tbg\t%s\n",
+      bg_grp, show(bg_icon, "-", "enter", "background agents", bg_text)
+
+    # The pids ride along in the hidden pid field so the preview can detail them
+    # without rebuilding the pid -> tty -> pane join.
+    if (orphans > 0)
+      printf "100\t~orphans\t0\t0\t-\t%s\tnote\t%s\n",
+        orphan_pids,
+        show("\033[90m●\033[0m outside", "-", "-", "not in tmux",
+             dim(orphans " Claude session" (orphans == 1 ? "" : "s") " running outside tmux — cannot jump"))
+  }

--- a/test/contract.sh
+++ b/test/contract.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Contract test for tmux-claude-session-manager.
+#
+# This plugin reads two very different surfaces, and they carry different risk:
+#
+#   documented  `claude agents --json` — field names and the state/status
+#               vocabularies are published in the Claude Code docs (agent-view).
+#               Asserted strictly: an unknown value fails, because that is
+#               exactly the drift we want to hear about.
+#
+#   internal    ~/.claude/projects/<slug>/<sessionId>.jsonl and its `ai-title`
+#               record. Undocumented, may move without notice. Asserted too, but
+#               they only feed the title and age columns, so a break here
+#               degrades the display rather than breaking the picker.
+#
+# Fixture checks need neither tmux nor a running Claude and always run. Live
+# checks skip themselves when there is nothing running, so an unattended run at
+# 04:00 reports "skipped", never a false alarm.
+#
+#   ./test/contract.sh          run everything
+#   ./test/contract.sh --quiet  print only failures and a one-line summary
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$DIR/scripts/helpers.sh"
+
+quiet=''; [ "${1:-}" = '--quiet' ] && quiet=1
+pass=0; fail=0; skip=0
+
+ok()   { pass=$((pass+1)); [ -n "$quiet" ] || printf '  \033[32mok\033[0m    %s\n' "$1"; }
+no()   { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
+sk()   { skip=$((skip+1)); [ -n "$quiet" ] || printf '  \033[90mskip\033[0m  %s (%s)\n' "$1" "$2"; }
+head_() { [ -n "$quiet" ] || printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+# ---------------------------------------------------------------- documented --
+head_ 'Documented: claude agents --json'
+
+agents="$(claude agents --json 2>/dev/null)"
+if [ -z "$agents" ] || ! printf '%s' "$agents" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  no 'returns a JSON array' 'claude agents --json produced nothing parseable'
+  agents='[]'
+else
+  ok 'returns a JSON array'
+fi
+
+n_all=$(printf '%s' "$agents" | jq 'length')
+if [ "$n_all" -eq 0 ]; then
+  sk 'field and vocabulary checks' 'no live sessions'
+else
+  # Always-present fields, per the docs table.
+  missing=$(printf '%s' "$agents" | jq -r '[.[] | select(has("cwd") and has("kind") and has("startedAt") | not)] | length')
+  [ "$missing" = 0 ] && ok 'every entry has cwd, kind, startedAt' \
+                     || no 'every entry has cwd, kind, startedAt' "$missing entries missing one"
+
+  bad=$(printf '%s' "$agents" | jq -r '[.[].kind] | unique - ["interactive","background"] | join(", ")')
+  [ -z "$bad" ] && ok 'kind is interactive|background' || no 'kind is interactive|background' "unknown: $bad"
+
+  # The vocabularies agents.sh branches on. A new value here means the picker is
+  # silently rendering it as the grey "?" row, or miscounting the background row.
+  bad=$(printf '%s' "$agents" | jq -r '[.[] | .state // empty] | unique - ["working","blocked","done","failed","stopped"] | join(", ")')
+  [ -z "$bad" ] && ok 'background state in documented set' || no 'background state in documented set' "undocumented: $bad"
+
+  bad=$(printf '%s' "$agents" | jq -r '[.[] | .status // empty] | unique - ["idle","busy","waiting"] | join(", ")')
+  [ -z "$bad" ] && ok 'interactive status in known set' || no 'interactive status in known set' "unknown: $bad"
+
+  # Documented: waitingFor is present whenever status is waiting.
+  n_wait=$(printf '%s' "$agents" | jq '[.[] | select(.status == "waiting")] | length')
+  if [ "$n_wait" -eq 0 ]; then
+    sk 'waiting entries carry waitingFor' 'nothing waiting'
+  else
+    bad=$(printf '%s' "$agents" | jq '[.[] | select(.status == "waiting" and (has("waitingFor") | not))] | length')
+    [ "$bad" = 0 ] && ok 'waiting entries carry waitingFor' || no 'waiting entries carry waitingFor' "$bad without it"
+  fi
+
+  # Interactive entries must expose a pid — the whole pid -> tty -> pane join
+  # depends on it, and background entries deliberately have none.
+  bad=$(printf '%s' "$agents" | jq '[.[] | select(.kind == "interactive" and (has("pid") | not))] | length')
+  [ "$bad" = 0 ] && ok 'interactive entries expose pid' || no 'interactive entries expose pid' "$bad without pid"
+fi
+
+# ----------------------------------------------------------------- internal --
+head_ 'Internal: transcript layout and ai-title'
+
+sid=$(printf '%s' "$agents" | jq -r '[.[] | select(.kind == "interactive") | .sessionId] | first // empty')
+if [ -z "$sid" ]; then
+  sk 'transcript path resolves' 'no interactive session'
+  sk 'ai-title parses' 'no interactive session'
+else
+  f="$(claude_transcript_path "$sid")"
+  if [ -n "$f" ] && [ -f "$f" ]; then
+    ok 'transcript path resolves'
+    if [ -n "$(claude_transcript_title "$f")" ]; then
+      ok 'ai-title parses to a non-empty title'
+    else
+      # Not fatal: the column blanks out, the picker still works.
+      no 'ai-title parses to a non-empty title' "no ^{\"type\":\"ai-title\"} record in $(basename "$f")"
+    fi
+  else
+    no 'transcript path resolves' "no transcript found for $sid under \${CLAUDE_CONFIG_DIR:-~/.claude}/projects/*/"
+  fi
+fi
+
+# ------------------------------------------------------------------ fixture --
+# Drives rows.awk with synthetic streams, so these run anywhere: no tmux, no
+# Claude, no network. This is the half that CI can run.
+head_ 'Fixture: row rendering'
+
+run_fixture() {
+  awk -F'\t' -v now=1000000 -v bg_attn="$1" -v bg_active="$2" -v projw=24 -v prefix='claude-' \
+    -f "$DIR/scripts/rows.awk"
+}
+fixture_streams() {
+  printf 'P\t4242\tpts/99\n'
+  printf 'T\t/dev/pts/99\t%%99\twork\twork:9.0\n'
+  printf 'M\tSID\t999400\tRework the upload endpoint\n'
+  printf 'A\t4242\t%s\tSID\t%s\t%s\n' "$1" "$2" "${3:-}"
+}
+
+out=$(fixture_streams waiting /srv/example/docs-site 'permission prompt' | run_fixture 0 0)
+row=$(printf '%s' "$out" | head -1)
+
+[ "$(printf '%s' "$row" | awk -F'\t' '{print NF}')" = 8 ] \
+  && ok 'row has 8 tab-separated fields' \
+  || no 'row has 8 tab-separated fields' "got $(printf '%s' "$row" | awk -F'\t' '{print NF}')"
+
+printf '%s' "$row" | grep -q 'permission prompt' \
+  && ok 'waiting row surfaces waitingFor' || no 'waiting row surfaces waitingFor'
+
+[ "$(printf '%s' "$row" | cut -f3)" = 0 ] \
+  && ok 'waiting ranks above idle and busy' || no 'waiting ranks above idle and busy'
+
+[ "$(printf '%s' "$row" | cut -f7)" = loose ] \
+  && ok 'pane outside the session prefix is loose' || no 'pane outside the session prefix is loose'
+
+# Age rolls up so it cannot overflow the column.
+out=$(printf 'P\t1\tpts/99\nT\t/dev/pts/99\t%%99\twork\twork:9.0\nM\tS\t560000\tT\nA\t1\tidle\tS\t/x\t\n' | run_fixture 0 0)
+printf '%s' "$out" | head -1 | grep -qE '[0-9]+d ' \
+  && ok 'multi-day age renders as days, not minutes' || no 'multi-day age renders as days, not minutes'
+
+# Worktrees fold into their repo group instead of each becoming a project of one.
+out=$(fixture_streams idle '/srv/example/monorepo/.claude/worktrees/fix-1' | run_fixture 0 0)
+printf '%s' "$out" | head -1 | grep -q 'monorepo/fix-1' \
+  && ok 'worktree folds into its repo group' || no 'worktree folds into its repo group'
+[ "$(printf '%s' "$out" | head -1 | cut -f2)" = /srv/example/monorepo ] \
+  && ok 'worktree sorts under the repo path' || no 'worktree sorts under the repo path'
+
+# Background row: pinned on top when anything needs you, parked at the bottom otherwise.
+out=$(fixture_streams idle /x | run_fixture 2 1)
+bg=$(printf '%s' "$out" | awk -F'\t' '$7 == "bg"')
+[ "$(printf '%s' "$bg" | cut -f1)" = '-1' ] && ok 'bg row pins to top when agents need you' || no 'bg row pins to top when agents need you'
+printf '%s' "$bg" | grep -q '2 need you, 1 running' && ok 'bg row reports both counts' || no 'bg row reports both counts'
+
+out=$(fixture_streams idle /x | run_fixture 0 3)
+bg=$(printf '%s' "$out" | awk -F'\t' '$7 == "bg"')
+[ "$(printf '%s' "$bg" | cut -f1)" = 99 ] && ok 'bg row sinks when nothing needs you' || no 'bg row sinks when nothing needs you'
+
+# A Claude with no tmux pane must be surfaced, never silently dropped.
+out=$(printf 'A\t7777\tidle\tS\t/x\t\n' | run_fixture 0 0)
+note=$(printf '%s' "$out" | awk -F'\t' '$7 == "note"')
+[ -n "$note" ] && ok 'session outside tmux gets a row' || no 'session outside tmux gets a row'
+[ "$(printf '%s' "$note" | cut -f6)" = 7777 ] \
+  && ok 'outside-tmux row carries its pids for the preview' || no 'outside-tmux row carries its pids for the preview'
+
+# --------------------------------------------------------------- end-to-end --
+head_ 'End-to-end: agents.sh against the live machine'
+
+if ! command -v tmux >/dev/null 2>&1 || ! tmux list-panes -a >/dev/null 2>&1; then
+  sk 'agents.sh produces well-formed rows' 'no tmux server'
+else
+  live=$("$DIR/scripts/agents.sh")
+  widths=$(printf '%s\n' "$live" | awk -F'\t' 'NF != 8' | wc -l)
+  [ "$widths" -eq 0 ] && ok 'every row has 8 fields' || no 'every row has 8 fields' "$widths malformed"
+
+  bad=0
+  while IFS= read -r r; do
+    case "$(printf '%s' "$r" | cut -f7)" in
+      loose | dedicated)
+        tmux display-message -p -t "$(printf '%s' "$r" | cut -f5)" '#{session_name}' >/dev/null 2>&1 || bad=$((bad+1)) ;;
+    esac
+  done <<< "$live"
+  [ "$bad" -eq 0 ] && ok 'every pane id resolves to a live pane' || no 'every pane id resolves to a live pane' "$bad dangling"
+fi
+
+# ------------------------------------------------------------------ summary --
+printf '\n%s\n' "$(printf '%d passed, %d failed, %d skipped' "$pass" "$fail" "$skip")"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Thanks for this plugin — the pid → tty → pane join is the part that makes it work, and it already handles several Claudes in one repo correctly. This builds on top of it.

## The problem

With one Claude per project the picker reads well. With several in the same repo the rows become near-identical — same status, same cwd — so the list tells you how many threads are open but not which is which:

```
● idle      37m  work:2.0   ~/code/foo
● idle      41m  work:1.0   ~/code/foo
● idle      45m  work:6.0   ~/code/foo
● working   28m  work:4.0   ~/code/foo
```

## After

```
● blocked     -  enter      background agents         3 need you
● idle       8m  work:2.0   foo                Create a something rather framework
● idle      12m  work:1.0   foo/fix-1381-liv  Update to latest main branch
● idle      16m  work:6.0   foo               Prepare system for big rollout
● waiting    2m  work:9.0   bar                    permission prompt — Refactor the planning rollup
● working   33m  work:4.0   foo               Address special report skill vents from Slack
```

## What changed

**Titles.** Claude Code appends an `ai-title` record to the transcript whenever its sense of the topic shifts, so the last one is a current, self-maintaining label. Read backwards, first hit wins.

**Grouping.** Rows cluster by project, and a project is ordered by its most urgent member — so grouping never buries something that needs you. Worktrees (`<repo>/.claude/worktrees/<name>`) fold into their repo rather than each becoming a project of one.

**`waitingFor`.** Documented alongside `status`, and it names what a waiting session is blocked on (permission prompt, input needed, sandbox request). That is the thing you triage on, so it leads the title.

**A background-agents row.** Background agents have no `pid`, so they have no tty and no pane and can never be rows you jump to. They collapse into one aggregate row that opens `claude agents`, pinned above everything while any is `blocked` or `failed` and parked at the bottom otherwise — a signal, not just a door. `ctrl-g` reaches it without hunting, and comes back via `--expect` rather than `become()`/`execute()`, since fzf's stdout is a command substitution here and anything launched from inside a binding renders into the variable instead of the popup.

**Sessions outside tmux.** Previously skipped by a bare `next`. An overview that hides a live session seemed worth a row saying it cannot be jumped to.

**`rows.awk`.** The row builder was a 90-line awk program quoted inside a shell string, so it could only be exercised against a live tmux with real agents running. As a file it can be driven from fixtures — which is what made the tests below possible. This is the largest diff but a pure move plus the new logic.

Smaller: age rolls up to hours/days (long sessions rendered `7342m`); the display is one pre-padded field because fzf rejoins `--with-nth` fields with the delimiter and tab stops jittered the columns; project width is `@claude_project_width`.

## Tests

`test/contract.sh` — 23 checks. The plugin reads two surfaces with different stability, and nothing distinguished them:

- **Documented** (`claude agents --json`): field presence and the `state`/`status` vocabularies are asserted strictly, so an undocumented value fails loudly. That is the drift worth hearing about — it caught a real bug while writing this, where `failed` was being counted as "running" in the background row.
- **Internal** (`~/.claude/projects/…` and `ai-title`): asserted too, but they only feed the title and age columns, so a break degrades the display rather than the picker.

Fixture checks drive `rows.awk` from synthetic streams — no tmux, no Claude, no network — so CI can run them. Live checks skip themselves when nothing is running, so an unattended run reports `skipped` rather than failing.

Verified against four simulated breakages (undocumented state, missing `waitingFor`, renamed status, renamed `ai-title` record); each fails naming the specific assumption.

Tested on Linux with tmux 3.5a, fzf 0.74.3, Claude Code 2.1.234. The `tac`/`tail -r` fallback follows the existing `md5sum`/`md5` and `stat -c`/`stat -f` pattern, but I have no macOS box to confirm on — worth a check.

Happy to split this into separate PRs (the `rows.awk` move, the title/grouping, the background row) if that reviews more easily.