### PR TITLE
fix(picker): load the agent list synchronously so early keys aren't lost

### DIFF
--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -35,8 +35,15 @@ fzf_options="$(get_tmux_option @claude_fzf_options '')"
 # ctrl-x kills the Claude process itself: a dedicated session dies with its last
 # window, while a loose pane keeps the shell that hosted it. The reload waits a
 # beat so the supervisor has dropped the agent from `claude agents --json`.
+#
+# --sync because agents.sh feeds fzf through a pipe: without it fzf paints an
+# interactive but *empty* picker at t=0 and only fills it once agents.sh returns.
+# Arrow keys pressed in that window are no-ops against zero rows and are lost,
+# while letters survive into the query — so the picker looks like it ignores the
+# arrow keys, the more so the busier the machine. It goes before extra_opts so
+# @claude_fzf_options can still override it with --no-sync.
 sel=$("$DIR/agents.sh" | fzf --ansi --delimiter='\t' --with-nth=5,6,7,8 \
-  --reverse --cycle --header='Claude agents · enter: jump · ctrl-x: kill' \
+  --reverse --cycle --sync --header='Claude agents · enter: jump · ctrl-x: kill' \
   --preview='tmux capture-pane -ept {2}' --preview-window='up,70%,follow' \
   --bind="ctrl-x:execute-silent(kill {3})+reload(sleep 0.3; $self --list)" \
   ${extra_opts[@]+"${extra_opts[@]}"})


### PR DESCRIPTION
## The problem

`picker.sh` runs `agents.sh | fzf`, so fzf starts at t=0 and paints an **interactive but empty** picker for as long as `agents.sh` takes to return. Keys pressed in that window are not queued: arrow keys are no-ops against zero rows and are discarded, while letters survive into the query.

So the picker doesn't just feel slow to open — it silently eats your first keystrokes, and it does so exactly in the 1.0–2.5s window measured under load in #23. The user-visible report that comes out of this is "the arrow keys don't work in the picker", which sounds like a key-encoding or terminal problem and doesn't lead anyone back to the latency.

## The fix

`--sync` makes fzf finish the initial load before it consumes key events. It goes *before* `extra_opts` so `@claude_fzf_options` can still override it with `--no-sync` for anyone who prefers the picker to appear instantly.

## Measurement

A pty harness reproducing the pipeline shape (a producer that sleeps, piped into fzf), delivering a single Down as soon as fzf paints, then Enter, n=6:

```
without --sync   one one two one one one   5/6 ignored
with    --sync   two two two two two two   6/6 applied
```

A letter typed in the same window always lands, which is why the failure reads as "the arrow keys are broken" rather than "the picker is slow".

## Note

This is complementary to #23 rather than an alternative: with `--sync` the picker still takes as long to appear, it just no longer loses what you typed at it.

Tested on tmux 3.7c / fzf 0.74.3 / macOS.
