### PR TITLE
feat(picker): Load the agent list from a cache for a faster startup

### DIFF
--- a/scripts/picker.sh
+++ b/scripts/picker.sh
@@ -2,7 +2,8 @@
 # Interactive picker for running Claude agents.
 #
 #   picker.sh           fzf picker; on enter, jumps to the chosen agent.
-#   picker.sh --list    print the rows only (used by fzf's ctrl-x reload).
+#   picker.sh --list    print the rows and refresh the cache (used by fzf's
+#                       async initial load and by the ctrl-x reload).
 #
 # Rows come from agents.sh, which pairs each running Claude with the tmux pane it
 # occupies. Two kinds of row jump differently:
@@ -14,7 +15,15 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers.sh
 . "$DIR/helpers.sh"
 
-[ "${1:-}" = '--list' ] && exec "$DIR/agents.sh"
+cache="${TMPDIR:-/tmp}/tmux-claude-agents-$(id -u).cache"
+
+if [ "${1:-}" = '--list' ]; then
+  tmp="$cache.$$"
+  "$DIR/agents.sh" >"$tmp" 2>/dev/null
+  mv -f "$tmp" "$cache" 2>/dev/null || rm -f "$tmp"
+  cat "$cache" 2>/dev/null
+  exit 0
+fi
 
 for tool in fzf jq claude; do
   command -v "$tool" >/dev/null 2>&1 || {
@@ -32,13 +41,25 @@ extra_opts=()
 fzf_options="$(get_tmux_option @claude_fzf_options '')"
 [ -n "$fzf_options" ] && eval "extra_opts=($fzf_options)"
 
+# Load the session list asynchronously
+list_cmd=("$self" --list)
+sync_opts=()
+now=$(date +%s)
+mtime=$(file_mtime "$cache")
+if [ -s "$cache" ] && [ -n "$mtime" ] && [ $((now - mtime)) -lt 600 ]; then
+  list_cmd=(cat "$cache")
+  sync_opts=(--bind "load:unbind(load)+reload-sync($self --list)")
+fi
+fzf --track --version >/dev/null 2>&1 && sync_opts+=(--track)
+
 # ctrl-x kills the Claude process itself: a dedicated session dies with its last
 # window, while a loose pane keeps the shell that hosted it. The reload waits a
 # beat so the supervisor has dropped the agent from `claude agents --json`.
-sel=$("$DIR/agents.sh" | fzf --ansi --delimiter='\t' --with-nth=5,6,7,8 \
+sel=$("${list_cmd[@]}" | fzf --ansi --delimiter='\t' --with-nth=5,6,7,8 \
   --reverse --cycle --header='Claude agents · enter: jump · ctrl-x: kill' \
   --preview='tmux capture-pane -ept {2}' --preview-window='up,70%,follow' \
   --bind="ctrl-x:execute-silent(kill {3})+reload(sleep 0.3; $self --list)" \
+  ${sync_opts[@]+"${sync_opts[@]}"} \
   ${extra_opts[@]+"${extra_opts[@]}"})
 
 [ -z "$sel" ] && exit 0


### PR DESCRIPTION
## The problem

`picker.sh` pipes `agents.sh` straight into fzf, so every open pays the full cost of enumerating agents before any rows appear. Under load that's the 1.0–2.5s window measured in #23, and it's the same window in which fzf silently discards early keystrokes (#24).

## The fix

`--list` now writes its output to a per-user cache under `$TMPDIR` (atomically, via a temp file + `mv`) in addition to printing it. On the next open, if the cache is fresh (< 10 minutes), the picker:

- starts fzf instantly from the cached rows, so the list is populated from the first frame and early arrow keys land on real rows instead of being dropped;
- refreshes the list in the background via a one-shot `load` binding that runs `reload-sync($self --list)`, so the rows are brought up to date without blocking the UI;
- passes `--track` (when the installed fzf supports it) so the cursor stays on the selected row when the refreshed list arrives.

With no fresh cache, behavior is unchanged: the list loads synchronously as before.

Resolves #24 — the keystroke loss there came from fzf idling on an empty list during the initial load; starting from the cache removes that empty window, and the async refresh path uses `reload-sync`, which doesn't drop input.

Complementary to #23: this doesn't make `agents.sh` itself faster, it just moves the wait off the critical path of opening the picker.